### PR TITLE
Role should be 'any' type to allow complex role definitions

### DIFF
--- a/examples/authorization/user.interface.ts
+++ b/examples/authorization/user.interface.ts
@@ -1,5 +1,5 @@
 export interface User {
   id: number;
   name: string;
-  roles: string[];
+  roles: any[];
 }

--- a/src/decorators/Authorized.ts
+++ b/src/decorators/Authorized.ts
@@ -5,9 +5,9 @@ import { getArrayFromOverloadedRest } from "../helpers/decorators";
 export type MethodOrPropDecorator = MethodDecorator & PropertyDecorator;
 
 export function Authorized(): MethodOrPropDecorator;
-export function Authorized(roles: string[]): MethodOrPropDecorator;
-export function Authorized(...roles: string[]): MethodOrPropDecorator;
-export function Authorized(...rolesOrRolesArray: Array<string | string[]>): MethodOrPropDecorator {
+export function Authorized(roles: any[]): MethodOrPropDecorator;
+export function Authorized(...roles: any[]): MethodOrPropDecorator;
+export function Authorized(...rolesOrRolesArray: Array<any | any[]>): MethodOrPropDecorator {
   const roles = getArrayFromOverloadedRest(rolesOrRolesArray);
 
   return (prototype: object, propertyKey: string | symbol) => {

--- a/src/interfaces/auth-checker.ts
+++ b/src/interfaces/auth-checker.ts
@@ -2,7 +2,7 @@ import { ResolverData } from "../types/action-data";
 
 export type AuthChecker<ContextType = {}> = (
   resolverData: ResolverData<ContextType>,
-  roles: string[],
+  roles: any[],
 ) => boolean | Promise<boolean>;
 
 export type AuthMode = "error" | "null";

--- a/src/metadata/definitions/resolver-metadata.ts
+++ b/src/metadata/definitions/resolver-metadata.ts
@@ -12,7 +12,7 @@ export interface BaseResolverMetadata {
   target: Function;
   handler: Function | undefined;
   params?: ParamMetadata[];
-  roles?: string[];
+  roles?: any[];
   middlewares?: Array<Middleware<any>>;
 }
 

--- a/src/metadata/metadata-storage.ts
+++ b/src/metadata/metadata-storage.ts
@@ -201,7 +201,7 @@ export class MetadataStorage {
     });
   }
 
-  private findFieldRoles(target: Function, fieldName: string): string[] | undefined {
+  private findFieldRoles(target: Function, fieldName: string): any[] | undefined {
     const authorizedField = this.authorizedFields.find(
       authField => authField.target === target && authField.fieldName === fieldName,
     );


### PR DESCRIPTION
Not every role can be defined as string, doing serialize-deserialize probably not the best idea. Inspired by `routing-controllers`