### PR TITLE
removed lines that provide unexpected behavior for false:

### DIFF
--- a/src/resolvers/validate-arg.ts
+++ b/src/resolvers/validate-arg.ts
@@ -7,10 +7,6 @@ export async function validateArg<T extends Object>(
   globalValidate: boolean | ValidatorOptions,
   argValidate?: boolean | ValidatorOptions,
 ): Promise<T | undefined> {
-  if (!arg) {
-    return;
-  }
-
   const validate = argValidate !== undefined ? argValidate : globalValidate;
   if (validate === false || arg == null || typeof arg !== "object") {
     return arg;


### PR DESCRIPTION
HI. I remove this 3 lines because of them I can`t pass boolean as a parameter for the query.
E.g.:
@Query(returns => [Weight], { description: 'Get all weights' })
  public async weights(@Arg('metric') metric: boolean): Promise<Weight[]> {
    return await getAll(metric);
  }
'''query{ weights(metric: false){name,weightId}}
With True eveything works) But with false....in this case I alwayse get undefined. 

P.S. I was convinced that nothing had changed in the tests. I also checked with my project that everything works. If there are any suspicions tell me, I'll try to find another solution to my situation.