### PR TITLE
Updated resolvers inheritance example

### DIFF
--- a/examples/resolvers-inheritance/person/person.resolver.ts
+++ b/examples/resolvers-inheritance/person/person.resolver.ts
@@ -19,7 +19,7 @@ const persons: Person[] = [
   },
 ];
 
-export const ResourceResolver = createResourceResolver(Person, persons);
+export const ResourceResolver = createResourceResolver(() => Person, persons);
 
 @Resolver(of => Person)
 export class PersonResolver extends ResourceResolver<Person> {

--- a/examples/resolvers-inheritance/recipe/recipe.resolver.ts
+++ b/examples/resolvers-inheritance/recipe/recipe.resolver.ts
@@ -11,7 +11,7 @@ const recipes: Recipe[] = [
   },
 ];
 
-export const ResourceResolver = createResourceResolver(Recipe, recipes);
+export const ResourceResolver = createResourceResolver(() => Recipe, recipes);
 
 @Resolver(of => Recipe)
 export class RecipeResolver extends ResourceResolver<Recipe> {


### PR DESCRIPTION
It is important to provide correct resolver type to an abstract resolver, Otherwise, field resolvers would not work.
#102 