### PR TITLE
Docs: Mutation type in resolvers

### DIFF
--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -187,7 +187,7 @@ input AddRecipeInput {
 }
 ```
 ```graphql
-type Query {
+type Mutation {
   addRecipe(data: AddRecipeInput!): Recipe!
 }
 ```


### PR DESCRIPTION
The Mutation annotation updates the Mutation type, not the Query type