### PR TITLE
docs(beginners,advanced): improve grammar in several doc pages

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -2,14 +2,14 @@
 title: Bootstrapping
 ---
 
-After creating our resolvers and types classes with other business-related code, we need to make our app running. At first we have to build the schema, then we can expose it by HTTP server, WebSockets or even MQTT.
+After creating our resolvers, types classes, and other business-related code, we need to make our app run. First we have to build the schema, then we can expose it by HTTP server, WebSockets or even MQTT.
 
-## Create executable schema
+## Create Executable Schema
 
-To create executable schema from types' and resolvers' definitions, you need to use `buildSchema` function.
-It takes configuration object as a parameter and returns a promise of `GraphQLSchema` object.
+To create an executable schema from type and resolver definitions, you need to use the `buildSchema` function.
+It takes a configuration object as a parameter and returns a promise of a `GraphQLSchema` object.
 
-In configuration object you need to provide `resolvers` property, which might be an array of resolver classes:
+In the configuration object you must provide a `resolvers` property, which can be an array of resolver classes:
 
 ```typescript
 import { FirstResolver, SecondResolver } from "../app/src/resolvers";
@@ -19,8 +19,8 @@ const schema = await buildSchema({
 });
 ```
 
-However, when there're several dozen of resolver classes, manual imports might be a tedious work.
-So you can also provide an array of path to resolver module files (they might be a glob):
+However, when there are several dozen of resolver classes, manual imports can be tedious.
+So you can also provide an array of paths to resolver module files instead, which can include globs:
 
 ```typescript
 const schema = await buildSchema({
@@ -33,7 +33,7 @@ const schema = await buildSchema({
 
 There are also other options related to advanced features like [authorization](./authorization.md) or [validation](./validation.md) - you can read about them in docs.
 
-To make `await` work, we need to wrap it in async function. Example of `main.ts` file:
+To make `await` work, we need to declare it as an async function. Example of `main.ts` file:
 
 ```typescript
 import { buildSchema } from "type-graphql";
@@ -51,7 +51,7 @@ bootstrap(); // actually run the async function
 
 ## Create HTTP GraphQL endpoint
 
-In most cases, the GraphQL app is served by a HTTP server. After building the schema we can create it using e.g. [`apollo-server`](https://github.com/apollographql/apollo-server) package:
+In most cases, the GraphQL app is served by a HTTP server. After building the schema we can create the GraphQL endpoint with a variety of tools such as [`graphql-yoga`](https://github.com/prisma/graphql-yoga) or [`apollo-server`](https://github.com/apollographql/apollo-server).  Here is an example using [`apollo-server`](https://github.com/apollographql/apollo-server):
 
 ```typescript
 import { ApolloServer } from "apollo-server";

--- a/docs/interfaces-and-inheritance.md
+++ b/docs/interfaces-and-inheritance.md
@@ -4,14 +4,14 @@ title: Interfaces and inheritance
 
 The main idea of TypeGraphQL is to create GraphQL types based on TypeScript classes.
 
-In object-oriented programming it is common to create interfaces which describes the contract that classes implementing them has to fulfill. We also compose the classes using inheritance mechanism. Hence TypeGraphQL support both GraphQL interfaces as well as composing types definition by extending the classes.
+In object-oriented programming it is common to create interfaces which describes the contract that classes implementing them has to fulfill. We also compose classes using inheritance. Hence TypeGraphQL supports both GraphQL interfaces as well as composing type definitions by extending the classes.
 
 ## Interfaces
-TypeScript has first class support for interfaces. Unfortunately, they exist only on compile-time, so we can't use them to build GraphQL schema on runtime by using decorators.
+TypeScript has first class support for interfaces. Unfortunately, they only exist at compile-time, so we can't use them to build GraphQL schema at runtime by using decorators.
 
-Luckily, we can use abstract class for this purpose - it behave almost like an interface (can't be "newed", can be implemented by class), it just won't stop developers from implementing a method or initializing a field. But until we do the same things like with an interface, we can safely use it.
+Luckily, we can use an abstract class for this purpose.  It behaves almost like an interface (can't be "newed", can be implemented by class), it just won't stop developers from implementing a method or initializing a field. But as long as we treat it like an interface, we can safely use it.
 
-So, how to create GraphQL interface definition? We create an abstract class and decorate it with `@InterfaceType()`. The rest is exactly the same as with object types - we use `@Field` to declare the shape of the type:
+So, how do you create GraphQL interface definition? We create an abstract class and decorate it with `@InterfaceType()`. The rest is exactly the same as with object types: we use `@Field` to declare the shape of the type:
 
 ```typescript
 @InterfaceType()

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -7,7 +7,7 @@ Besides [declaring GraphQL's object types](./types-and-fields.md), TypeGraphQL a
 ## Queries and mutations
 
 ### Resolvers classes
-At first, you have to create a resolver class and annotate it with `@Resolver()` decorator. This class will behave like a controller known from classic REST frameworks:
+First you have to create a resolver class and annotate it with `@Resolver()` decorator. This class will behave like a controller from classic REST frameworks:
 ```typescript
 @Resolver()
 class RecipeResolver {
@@ -15,7 +15,7 @@ class RecipeResolver {
 }
 ```
 
-You can use DI framework (as described in [dependency injection docs](./dependency-injection.md)) to inject class dependencies (like services or repositories) or store data inside resolvers class - it's guaranteed to be a single instance per app.
+You can use a DI framework (as described in [dependency injection docs](./dependency-injection.md)) to inject class dependencies (like services or repositories) or store data inside resolvers class - it's guaranteed to be a single instance per app.
 ```typescript
 @Resolver()
 class RecipeResolver {
@@ -23,7 +23,7 @@ class RecipeResolver {
 }
 ```
 
-Then you can create class methods which will handle queries and mutations. For example let's add `recipes` query that will return a collection of all recipes:
+Then you can create class methods which will handle queries and mutations. For example let's add the `recipes` query to return a collection of all recipes:
 ```typescript
 @Resolver()
 class RecipeResolver {
@@ -37,8 +37,8 @@ class RecipeResolver {
 ```
 
 We also need to do two things.
-The first is to add `@Query` decorator (it marks the class method as the GraphQL's query).
-The second is to provide the return type - the method is async so reflection metadata system shows that the return type is `Promise` of sth, so we have to add `returns => [Recipe]` decorator's parameter to declare that it will be an array of `Recipe` object types.
+The first is to add the `@Query` decorator, which marks the class method as a GraphQL query.
+The second is to provide the return type.  Since the method is async, the reflection metadata system shows the return type as `Promise`, so we have to add the decorator's parameter as `returns => [Recipe]` to declare it resolve to an array of `Recipe` object types.
 ```typescript
 @Resolver()
 class RecipeResolver {
@@ -54,7 +54,7 @@ class RecipeResolver {
 ### Arguments
 Usually queries have some arguments - it might be an id of the resource, the search phrase or pagination settings. TypeGraphQL allows you to define the arguments in two ways.
 
-First is the inline method using `@Arg()` decorator. The drawback is the need of repeating argument name (reflection system limitation) in decorator parameter.
+First is the inline method using `@Arg()` decorator. The drawback is the need of repeating argument name (due to a reflection system limitation) in the decorator parameter.
 ```typescript
 @Resolver()
 class RecipeResolver {
@@ -67,7 +67,7 @@ class RecipeResolver {
   }
 }
 ```
-It's quite good when there are up to 2-3 args but when you have many more, the resolver's method definitions becomes bloated. In that case you can use the args class definition. It looks like the object type class but it has `@ArgsType()` decorator on top.
+This works well when there are 2 - 3 args.  But when you have many more, the resolver's method definitions becomes bloated. In that case you can use a class definition to describe the arguments. It looks like the object type class but it has `@ArgsType()` decorator on top.
 ```typescript
 @ArgsType()
 class GetRecipesArgs {
@@ -82,7 +82,7 @@ class GetRecipesArgs {
 }
 ```
 You can define default values for optional fields (remember about `nullable: true`!) as well as helper methods.
-Also, this way of declaring arguments allows you to perform its validation - more details about this feature you can find in [validation docs](./validation.md).
+Also, this way of declaring arguments allows you to perform validation.  You can find more details about this feature in [the validation docs](./validation.md).
 
 ```typescript
 @ArgsType()
@@ -160,7 +160,7 @@ class AddRecipeInput implements Partial<Recipe> {
 
 After that we can use the `AddRecipeInput` type in our mutation. We can do this inline (using `@Arg()` decorator) or as a field of the args class like in query's example above.
 
-We might also need access to the context. To achieve this we use `@Ctx()` decorator with optional user-defined `Context` interface:
+We might also need access to the context. To achieve this we use the `@Ctx()` decorator with the optional user-defined `Context` interface:
 ```typescript
 @Resolver()
 class RecipeResolver {
@@ -177,9 +177,9 @@ class RecipeResolver {
   }
 }
 ```
-Because our method is synchronous and explicitly returns `Recipe`, we can omit `@Mutation()` type annotation.
+Because our method is synchronous and explicitly returns `Recipe`, we can omit the `@Mutation()` type annotation.
 
-This declarations will result in the following parts of the schema in SDL:
+This declaration will result in the following part of the schema in SDL:
 ```graphql
 input AddRecipeInput {
   title: String!
@@ -192,12 +192,12 @@ type Mutation {
 }
 ```
 
-By using parameter decorators, we can get rid of the unnecessary parameters like root value that bloat our method definition and have to be ignored with `_` parameter name. Also, we can achieve clean separation between GraphQL and our business code with decorators abstraction, so our resolvers and their methods behave just like services which we can easily unit-test.
+By using parameter decorators, we can get rid of the unnecessary parameters (like `root`) that bloat our method definition and have to be ignored by prefixing the parameter name with `_`. Also, we can achieve a clean separation between GraphQL and our business code with decorators, so our resolvers and their methods behave just like services which we can easily unit-test.
 
 ## Field resolvers
-Queries and mutations are not the only type of resolvers. We often create object type's field resolvers, e.g. when `user` type has field `posts` which we have to resolve by fetching relation data from the database.
+Queries and mutations are not the only type of resolvers. We often create object type field resolvers (e.g. when a `user` type has a field `posts`) which we have to resolve by fetching relational data from the database.
 
-Field resolvers in TypeGraphQL are very similar to queries and mutations - we create them as method of the resolver class but with a few modification. Firstly, we need to declare which object type's fields we are resolving by providing the type to `@Resolver` decorator:
+Field resolvers in TypeGraphQL are very similar to queries and mutations - we create them as a method on the resolver class but with a few modifications. Firstly, we need to declare which object type's fields we are resolving by providing the type to the `@Resolver` decorator:
 ```typescript
 @Resolver(of => Recipe)
 class RecipeResolver {
@@ -205,8 +205,8 @@ class RecipeResolver {
 }
 ```
 
-Then we can create the class method that become field resolver.
-In our example we have `averageRating` field in `Recipe` object type that should calculate the average from the `ratings` array.
+Then we can create the class method that become the field resolver.
+In our example we have the `averageRating` field in the `Recipe` object type that should calculate the average from the `ratings` array.
 ```typescript
 @Resolver(of => Recipe)
 class RecipeResolver {
@@ -218,7 +218,7 @@ class RecipeResolver {
 }
 ```
 
-We need to mark the method as field resolver with `@FieldResolver()` decorator. Because we've defined the type of the field in `Recipe` class definition, there's no need to do this again. We also need to decorate the method's parameters with `@Root` to inject the recipe object.
+We need to mark the method as a field resolver with the `@FieldResolver()` decorator. Because we've defined the type of the field in the `Recipe` class definition, there's no need to do this again. We also need to decorate the method's parameters with `@Root` to inject the recipe object.
 ```typescript
 @Resolver(of => Recipe)
 class RecipeResolver {
@@ -231,8 +231,8 @@ class RecipeResolver {
 }
 ```
 
-For enhanced type-safe you can implement the `ResolverInterface<Recipe>`.
-It's a small helper that will check if the return type of e.g. `averageRating` method is matching the `averageRating` property of the `Recipe` class
+For enhanced type safety you can implement the `ResolverInterface<Recipe>` interface.
+It's a small helper that will check if the return type of field resolver methods, like `averageRating(...)`, match the `averageRating` property of the `Recipe` class
 and whether the first parameter of the method is the object type (`Recipe` class).
 ```typescript
 @Resolver(of => Recipe)
@@ -246,7 +246,7 @@ class RecipeResolver implements ResolverInterface<Recipe> {
 }
 ```
 
-Example implementation of the `averageRating` field resolver:
+Here is a full sample implementation of the `averageRating` field resolver:
 ```typescript
 @Resolver(of => Recipe)
 class RecipeResolver implements ResolverInterface<Recipe> {
@@ -262,7 +262,7 @@ class RecipeResolver implements ResolverInterface<Recipe> {
 }
 ```
 
-For simple resolvers like `averageRating` calculation or deprecated fields that behave like aliases, you can create the field resolvers inline in object type's class definition:
+For simple resolvers like `averageRating` or deprecated fields that behave like aliases, you can create the field resolvers inline in object type's class definition:
 
 ```typescript
 @ObjectType()
@@ -289,8 +289,7 @@ class Recipe {
 }
 ```
 
-However, use this way of creating field resolvers only if the implementation is simple.
-If the code is more complicated and perform side effects (api call, db fetching), use resolver class's method instead - you can leverage dependency injection mechanism, really helpful in testing:
+However, if the code is more complicated and has side effects (i.e. api calls, fetching from databases), use a resolver class's method instead.  That way you can leverage the dependency injection mechanism, which is really helpful in testing.  For example:
 
 ```typescript
 @Resolver(of => Recipe)
@@ -314,5 +313,5 @@ Note that if a field name of a field resolver doesn't exit in resolver object ty
 Inheritance of resolver classes is an advanced topic covered in [interfaces and inheritance docs](./interfaces-and-inheritance.md#resolvers-inheritance).
 
 ## Examples
-This code samples are made up just for tutorial docs purpose.
-You can find more advanced, real examples in [examples folder](https://github.com/19majkel94/type-graphql/tree/master/examples).
+These code samples are made up just for tutorial purposes.
+You can find more advanced, real examples in the repository [examples folder](https://github.com/19majkel94/type-graphql/tree/master/examples).

--- a/docs/scalars.md
+++ b/docs/scalars.md
@@ -25,9 +25,9 @@ class MysteryObject {
   probability: number;
 }
 ```
-In the last case you can omit the `type => Float` since JavaScript `Number` will become `GraphQLFloat` in schema automatically.
+In the last case you can omit the `type => Float` since JavaScript `Number` will become `GraphQLFloat` in the schema automatically.
 
-Other scalars - `GraphQLString` and `GraphQLBoolean` doesn't need aliases - when it's possible, they will be reflected automatically:
+Other scalars - i.e. `GraphQLString` and `GraphQLBoolean` - do not need aliases.  When possible, they will be reflected automatically:
 ```typescript
 @ObjectType()
 class User {
@@ -52,8 +52,8 @@ class SampleObject {
 }
 ```
 
-## Built-in scalars
-TypeGraphQL provides built-in scalars for `Date` type. There are two versions of this scalars:
+## Date Scalars
+TypeGraphQL provides built-in scalars for the `Date` type. There are two versions of this scalar:
 - timestamp based (`"timestamp"`) - `1518037458374`
 - ISO format (`"isoDate"`) - `"2018-02-07T21:04:39.573Z"`
 
@@ -77,12 +77,12 @@ class User {
   registrationDate: Date;
 }
 ```
-Be aware to use `ts-node` with `--type-check` flag due to a [Date reflection bug](https://github.com/TypeStrong/ts-node/issues/511).
+If you use `ts-node`, be aware you must execute it with the `--type-check` flag due to a [Date reflection bug](https://github.com/TypeStrong/ts-node/issues/511).
 
-## Custom scalars
+## Custom Scalars
 TypeGraphQL also support custom scalar types.
 
-First of all, you need to create your own `GraphQLScalarType` instance (or import the scalar type from 3rd-party npm library). Example for Mongo's ObjectId:
+First of all, you need to create your own `GraphQLScalarType` instance or import the scalar type from a 3rd-party npm library. For example, Mongo's ObjectId:
 ```typescript
 import { GraphQLScalarType, Kind } from "graphql";
 import { ObjectId } from "mongodb";
@@ -123,7 +123,7 @@ class User {
 }
 ```
 
-Optionally, you can declare the association between reflected property type and your scalars to automatically map them (no need to explicit type annotation!):
+Optionally, you can declare the association between the reflected property type and your scalars to automatically map them (no need to explicit type annotation!):
 ```typescript
 @ObjectType()
 class User {
@@ -132,7 +132,7 @@ class User {
 }
 ```
 
-All you need to do is register the association map in `buildSchema` options:
+All you need to do is register the association map in the `buildSchema` options:
 ```typescript
 import { ObjectId } from "mongodb";
 import { ObjectIdScalar } from "../my-scalars/ObjectId";
@@ -143,4 +143,4 @@ const schema = await buildSchema({
   scalarsMap: [{ type: ObjectId, scalar: ObjectIdScalar }],
 });
 ```
-However, be aware that this will work only when TypeScript reflection mechanism can handle it. So your class property type must be the `class`, not an enum, union or an interface.
+However, be aware that this will work only when the TypeScript reflection mechanism can handle it. So your class property type must be the `class`, not an enum, union or an interface.

--- a/docs/types-and-fields.md
+++ b/docs/types-and-fields.md
@@ -48,11 +48,11 @@ For simple types (like `string` or `boolean`) it's enough but unfortunately, due
 - `@Field(type => [Rate])` (the recommended way - explicit `[ ]` syntax for Array)
 - `@Field(itemType => Rate)` (`array` is inferred from reflection - also ok but prone to error)
 
-Why function syntax, not simple `{ type: Rate }` config object? Because this way we solve problems with circular dependencies (e.g. Post <--> User), so it was adopted as a convention. You can use the shorthand syntax `@Field(() => Rate)` if you want to safe some keystrokes but it might be less readable for others.
+Why function syntax, not simple `{ type: Rate }` config object? Because this way we solve problems with circular dependencies (e.g. Post <--> User), so it was adopted as a convention. You can use the shorthand syntax `@Field(() => Rate)` if you want to save some keystrokes but it might be less readable for others.
 
-For nullable properties, like `averageRating` (it might be not defined when recipe has no ratings yet), we mark the class property as optional with `?:` operator and also have to pass `{ nullable: true }` decorator parameter. Be aware, that when you declare your type as e.g. `string | null`, you need to explicit provide the type to `@Field` decorator.
+For nullable properties like `averageRating` (it might be not defined when recipe has no ratings yet), we mark the class property as optional with `?:` operator and also have to pass `{ nullable: true }` decorator parameter. Be aware that when you declare your type as `string | null`, you need to explicitly provide the type to the `@Field` decorator.
 
-In config object we can also provide `description` and `deprecationReason` for GraphQL schema purposes.
+In the config object we can also provide `description` and `deprecationReason` for GraphQL schema purposes.
 
 So after this changes our example class would look like this:
 ```typescript
@@ -103,7 +103,7 @@ type Rate {
 }
 ```
 
-As you could see, for `id` property of `Recipe` we've passed `type => ID` and for `value` field of `Rate` - `type => Int`. This way we can overwrite the inferred type from reflection metadata, in this case for ID and Int scalars - you can read more about them in [scalars docs](./scalars.md), there is also a section about the built-in `Date` scalar. 
+As you could see, for `id` property of `Recipe` we've passed `type => ID` and for `value` field of `Rate` - `type => Int`. This way we can overwrite the inferred type from reflection metadata. You can read more about the ID and Int scalars in [the scalars docs](./scalars.md). There is also a section about the built-in `Date` scalar. 
 
 Also the `user` property doesn't have `@Field()` decorator - this way we can hide some properties of our data model. In this case we need to store in database `user` info inside `Rate` object to prevent multiple rates but we don't want to make it public, accessible to every API consumer.
 


### PR DESCRIPTION
This improves the sentence structure in various places of the documentation.
It does not change the content, and avoids changing the already-excellent
sample code in the docs.