### PR TITLE
Fix #206 

### DIFF
--- a/src/decorators/Resolver.ts
+++ b/src/decorators/Resolver.ts
@@ -24,7 +24,7 @@ export function Resolver(
 
   return target => {
     const getObjectType = objectTypeOrTypeFunc
-      ? objectTypeOrTypeFunc.prototype
+      ? objectTypeOrTypeFunc.name !== ""
         ? () => objectTypeOrTypeFunc as ClassType
         : (objectTypeOrTypeFunc as ClassTypeResolver)
       : () => {


### PR DESCRIPTION
This patch uses function name to determine the type of Resolver decorator's argument.
It can fix the issue #206