### PR TITLE
use Object.create instead of new to avoid constructor side effects

### DIFF
--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -65,7 +65,7 @@ export function convertToType(Target: any, data?: object): object | undefined {
     return data;
   }
 
-  return Object.assign(new Target(), data);
+  return Object.assign(Object.create(Target.prototype), data);
 }
 
 export function getEnumValuesMap<T extends object>(enumObject: T) {


### PR DESCRIPTION
I've encountered a problem with a resolver, when code is invoked to create an instance of a class. Unfortunately, the constructor of my class is expecting a non-optional argument, and would fail without it.

Therefore I recommend creating the instance of the class without invoking the constructor, using ```Object.create(Type.prototype)```

see also https://stackoverflow.com/a/50856428