### PR TITLE
Use PORT constant previously defined by doc author

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -68,7 +68,7 @@ async function bootstrap() {
   });
 
   // Start the server
-  const { url } = await server.listen(4000);
+  const { url } = await server.listen(PORT);
   console.log(`Server is running, GraphQL Playground available at ${url}`);
 }
 


### PR DESCRIPTION
It looks like intention of an author was to dynamically calculate the port based on environment, but finally have used hardcoded port instead which might lead to misunderstandment of the example.