### PR TITLE
Circular dependencies fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - add support for passing `PrintSchemaOptions` in `buildSchema.emitSchemaFile` (e.g. `commentDescriptions: true` to restore previous behavior)
 - add `buildTypeDefsAndResolvers` utils function for generating apollo-like `typeDefs` and `resolvers` pair (#233)
 
+## Fixes
+- fix calling return type getter function `@Field(type => Foo)` before finishing module evaluation (allow for extending circular classes using `require`)
+
 ## v0.16.0
 ### Features
 - add support for default values in schema (#203)

--- a/src/helpers/findType.ts
+++ b/src/helpers/findType.ts
@@ -48,14 +48,14 @@ export function findType({
     options.array = true;
   }
 
-  if (returnTypeFunc && Array.isArray(returnTypeFunc())) {
-    options.array = true;
-  }
-
   if (returnTypeFunc) {
-    const getType = Array.isArray(returnTypeFunc())
-      ? () => (returnTypeFunc() as [TypeValue])[0]
-      : (returnTypeFunc as TypeValueThunk);
+    const getType = () => {
+      if (Array.isArray(returnTypeFunc())) {
+        options.array = true;
+        return (returnTypeFunc() as [TypeValue])[0];
+      }
+      return returnTypeFunc();
+    };
     return {
       getType,
       typeOptions: options,

--- a/tests/helpers/circular-refs/good/CircularRef1.ts
+++ b/tests/helpers/circular-refs/good/CircularRef1.ts
@@ -2,8 +2,17 @@ import { Field, ObjectType } from "../../../../src";
 
 import { CircularRef2 } from "./CircularRef2";
 
+let hasModuleFinishedInitialLoad = false;
+
 @ObjectType()
 export class CircularRef1 {
-  @Field(type => CircularRef2)
-  ref2Field: any;
+  @Field(type => {
+    if (!hasModuleFinishedInitialLoad) {
+      throw new Error("Field type function was called synchronously during module load");
+    }
+    return [CircularRef2];
+  })
+  ref2Field: any[];
 }
+
+hasModuleFinishedInitialLoad = true;

--- a/tests/helpers/circular-refs/good/CircularRef2.ts
+++ b/tests/helpers/circular-refs/good/CircularRef2.ts
@@ -2,8 +2,17 @@ import { Field, ObjectType } from "../../../../src";
 
 import { CircularRef1 } from "./CircularRef1";
 
+let hasModuleFinishedInitialLoad = false;
+
 @ObjectType()
 export class CircularRef2 {
-  @Field(type => CircularRef1)
-  ref1Field: any;
+  @Field(type => {
+    if (!hasModuleFinishedInitialLoad) {
+      throw new Error("Field type function was called synchronously during module load");
+    }
+    return [CircularRef1];
+  })
+  ref1Field: any[];
 }
+
+hasModuleFinishedInitialLoad = true;


### PR DESCRIPTION
Tweaks the implementation of `findType` so that the return type function is called lazily rather than synchronously. This allows users to define a lazily-loaded type in that type function, and not create problematic circular dependency loops:

```ts
@Field(_type => require('./some/other/class'))
       // ^ this function won't be invoked until after the module finishes loading
```