### PR TITLE
Limit container scope to single schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- here goes all the unreleased changes descriptions -->
 ### Features
 - **Breaking Change**: make `graphql-js` packages a peer dependencies, bump `graphql` to `^14.1.1` and `@types/graphql` to `^14.0.5` (#239)
+- **Breaking Change**: remove `useContainer` function and allow to register container by `buildSchema` options (#241)
 - **Breaking Change**: change the default `PrintSchemaOptions` option `commentDescriptions` to false (no more `#` comments in SDL)
 - add support for passing `PrintSchemaOptions` in `buildSchema.emitSchemaFile` (e.g. `commentDescriptions: true` to restore previous behavior)
 - add `buildTypeDefsAndResolvers` utils function for generating apollo-like `typeDefs` and `resolvers` pair (#233)

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -11,18 +11,17 @@ TypeGraphQL supports this technique by allowing users to provide their IoC conta
 The usage of this feature is very simple - all you need to do is to register 3rd party container. Example using TypeDI:
 
 ```typescript
-import { useContainer, buildSchema } from "type-graphql";
+import { buildSchema } from "type-graphql";
 // import your IoC container
 import { Container } from "typedi";
 
 import { SampleResolver } from "./resolvers";
 
-// register the 3rd party IOC container
-useContainer(Container);
-
 // build the schema as always
 const schema = await buildSchema({
   resolvers: [SampleResolver],
+  // register the 3rd party IOC container
+  container: Container;
 });
 ```
 
@@ -81,16 +80,20 @@ At first you need to provide a container resolver function. It takes the resolve
 For simple container libraries you may define it inline, e.g. using `TypeDI`:
 
 ```typescript
-useContainer<TContext>(({ context }) => Container.of(context.requestId));
-```
-
-For some other advanced libraries, you might need to create an instance of the container, place it in the context object and then retrieve it in `useContainer` getter function:
-
-```typescript
-useContainer<TContext>(({ context }) => context.container);
+await buildSchema({
+  container: (({ context }: ResolverData<TContext>) => Container.of(context.requestId));
+};
 ```
 
 The tricky part is where the `context.requestId` comes from. Unfortunately, you need to provide it manually using hooks that are exposed by HTTP GraphQL middlewares like `express-graphql`, `apollo-server` or `graphql-yoga`.
+
+For some other advanced libraries, you might need to create an instance of the container, place it in the context object and then retrieve it in `container` getter function:
+
+```typescript
+await buildSchema({
+  container: (({ context }: ResolverData<TContext>) => context.container);
+};
+```
 
 Example using `TypeDI` and `apollo-server` with the `context` creation method:
 
@@ -136,7 +139,7 @@ And basically that's it! The configuration of container is done and TypeGraphQL 
 
 The only thing that left is the container configuration - you need to check out the docs for your container library (`InversifyJS`, `injection-js`, `TypeDI` or other) to get know how to setup a lifetime of the injectable objects (transient, scoped or singleton).
 
-**Be aware** that some libraries (like `TypeDI`) by default creates new instances for every scoped container, so you might experience a **significant grow of a memory usage** and a some decrease in query resolving speed, so please be careful with using this feature!
+> Be aware that some libraries (like `TypeDI`) by default creates new instances for every scoped container, so you might experience a **significant grow of a memory usage** and a some decrease in query resolving speed, so please be careful with using this feature!
 
 ### Example
 

--- a/examples/middlewares/index.ts
+++ b/examples/middlewares/index.ts
@@ -1,19 +1,18 @@
 import "reflect-metadata";
 import Container from "typedi";
 import { ApolloServer } from "apollo-server";
-import { useContainer, buildSchema, formatArgumentValidationError } from "../../src";
+import { buildSchema, formatArgumentValidationError } from "../../src";
 
 import { RecipeResolver } from "./recipe/recipe.resolver";
 import { ResolveTimeMiddleware } from "./middlewares/resolve-time";
 import { ErrorLoggerMiddleware } from "./middlewares/error-logger";
 
 async function bootstrap() {
-  useContainer(Container);
-
   // build TypeGraphQL executable schema
   const schema = await buildSchema({
     resolvers: [RecipeResolver],
     globalMiddlewares: [ErrorLoggerMiddleware, ResolveTimeMiddleware],
+    container: Container,
   });
 
   // Create GraphQL server

--- a/examples/resolvers-inheritance/index.ts
+++ b/examples/resolvers-inheritance/index.ts
@@ -1,17 +1,16 @@
 import "reflect-metadata";
 import { ApolloServer } from "apollo-server";
 import { Container } from "typedi";
-import { buildSchema, useContainer } from "../../src";
+import { buildSchema } from "../../src";
 
 import { RecipeResolver } from "./recipe/recipe.resolver";
 import { PersonResolver } from "./person/person.resolver";
-
-useContainer(Container);
 
 async function bootstrap() {
   // build TypeGraphQL executable schema
   const schema = await buildSchema({
     resolvers: [RecipeResolver, PersonResolver],
+    container: Container,
   });
 
   // Create GraphQL server

--- a/examples/typeorm-basic-usage/index.ts
+++ b/examples/typeorm-basic-usage/index.ts
@@ -16,7 +16,6 @@ export interface Context {
 }
 
 // register 3rd party IOC container
-TypeGraphQL.useContainer(Container);
 TypeORM.useContainer(Container);
 
 async function bootstrap() {
@@ -43,6 +42,7 @@ async function bootstrap() {
     // build TypeGraphQL executable schema
     const schema = await TypeGraphQL.buildSchema({
       resolvers: [RecipeResolver, RateResolver],
+      container: Container,
     });
 
     // create mocked context

--- a/examples/typeorm-lazy-relations/index.ts
+++ b/examples/typeorm-lazy-relations/index.ts
@@ -12,7 +12,6 @@ import { seedDatabase } from "./helpers";
 import { Context } from "./resolvers/types/context";
 
 // register 3rd party IOC container
-TypeGraphQL.useContainer(Container);
 TypeORM.useContainer(Container);
 
 async function bootstrap() {
@@ -39,6 +38,7 @@ async function bootstrap() {
     // build TypeGraphQL executable schema
     const schema = await TypeGraphQL.buildSchema({
       resolvers: [RecipeResolver],
+      container: Container,
     });
 
     // create mocked context

--- a/examples/using-container/index.ts
+++ b/examples/using-container/index.ts
@@ -1,13 +1,10 @@
 import "reflect-metadata";
 import { ApolloServer } from "apollo-server";
 import { Container } from "typedi";
-import { useContainer, buildSchema } from "../../src";
+import { buildSchema } from "../../src";
 
 import { RecipeResolver } from "./recipe-resolver";
 import { sampleRecipes } from "./sample-recipes";
-
-// register 3rd party IOC container
-useContainer(Container);
 
 // put sample recipes in container
 Container.set({ id: "SAMPLE_RECIPES", factory: () => sampleRecipes.slice() });
@@ -16,6 +13,8 @@ async function bootstrap() {
   // build TypeGraphQL executable schema
   const schema = await buildSchema({
     resolvers: [RecipeResolver],
+    // register 3rd party IOC container
+    container: Container,
   });
 
   // Create GraphQL server

--- a/examples/using-scoped-container/index.ts
+++ b/examples/using-scoped-container/index.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 import { ApolloServer } from "apollo-server";
 import Container, { ContainerInstance } from "typedi";
-import { useContainer, buildSchema, ResolverData } from "../../src";
+import { buildSchema, ResolverData } from "../../src";
 
 import { RecipeResolver } from "./recipe/recipe.resolver";
 import { Context } from "./types";
@@ -10,12 +10,11 @@ import { setSamplesInContainer } from "./recipe/recipe.samples";
 async function bootstrap() {
   setSamplesInContainer();
 
-  // register our custom, scoped IOC container by passing a extracting from resolver data function
-  useContainer<Context>(({ context }) => context.container);
-
   // build TypeGraphQL executable schema
   const schema = await buildSchema({
     resolvers: [RecipeResolver],
+    // register our custom, scoped IOC container by passing a extracting from resolver data function
+    container: ({ context }: ResolverData<Context>) => context.container,
   });
 
   // Create GraphQL server

--- a/src/resolvers/helpers.ts
+++ b/src/resolvers/helpers.ts
@@ -5,13 +5,7 @@ import { ParamMetadata } from "../metadata/definitions";
 import { convertToType } from "../helpers/types";
 import { validateArg } from "./validate-arg";
 import { ResolverData, AuthChecker, AuthMode } from "../interfaces";
-import { UnauthorizedError, ForbiddenError } from "../errors";
-import {
-  Middleware,
-  MiddlewareInterface,
-  MiddlewareFn,
-  MiddlewareClass,
-} from "../interfaces/Middleware";
+import { Middleware, MiddlewareFn, MiddlewareClass } from "../interfaces/Middleware";
 import { IOCContainer } from "../utils/container";
 import { AuthMiddleware } from "../helpers/auth-middleware";
 
@@ -73,6 +67,7 @@ export function applyAuthChecker(
 }
 
 export async function applyMiddlewares(
+  container: IOCContainer,
   resolverData: ResolverData<any>,
   middlewares: Array<Middleware<any>>,
   resolverHandlerFunction: () => any,
@@ -90,7 +85,7 @@ export async function applyMiddlewares(
       const currentMiddleware = middlewares[currentIndex];
       // arrow function or class
       if (currentMiddleware.prototype !== undefined) {
-        const middlewareClassInstance = IOCContainer.getInstance(
+        const middlewareClassInstance = container.getInstance(
           currentMiddleware as MiddlewareClass<any>,
           resolverData,
         );

--- a/src/schema/build-context.ts
+++ b/src/schema/build-context.ts
@@ -4,6 +4,7 @@ import { PubSubEngine, PubSub, PubSubOptions } from "graphql-subscriptions";
 
 import { AuthChecker, AuthMode } from "../interfaces";
 import { Middleware } from "../interfaces/Middleware";
+import { ContainerType, ContainerGetter, IOCContainer } from "../utils/container";
 
 export type DateScalarMode = "isoDate" | "timestamp";
 
@@ -24,6 +25,7 @@ export interface BuildContextOptions {
   authMode?: AuthMode;
   pubSub?: PubSubEngine | PubSubOptions;
   globalMiddlewares?: Array<Middleware<any>>;
+  container?: ContainerType | ContainerGetter<any>;
 }
 
 export abstract class BuildContext {
@@ -34,6 +36,7 @@ export abstract class BuildContext {
   static authMode: AuthMode;
   static pubSub: PubSubEngine;
   static globalMiddlewares: Array<Middleware<any>>;
+  static container: IOCContainer;
 
   /**
    * Set static fields with current building context data
@@ -42,18 +45,23 @@ export abstract class BuildContext {
     if (options.dateScalarMode !== undefined) {
       this.dateScalarMode = options.dateScalarMode;
     }
+
     if (options.scalarsMap !== undefined) {
       this.scalarsMaps = options.scalarsMap;
     }
+
     if (options.validate !== undefined) {
       this.validate = options.validate;
     }
+
     if (options.authChecker !== undefined) {
       this.authChecker = options.authChecker;
     }
+
     if (options.authMode !== undefined) {
       this.authMode = options.authMode;
     }
+
     if (options.pubSub !== undefined) {
       if ("eventEmitter" in options.pubSub) {
         this.pubSub = new PubSub(options.pubSub as PubSubOptions);
@@ -61,9 +69,12 @@ export abstract class BuildContext {
         this.pubSub = options.pubSub as PubSubEngine;
       }
     }
+
     if (options.globalMiddlewares) {
       this.globalMiddlewares = options.globalMiddlewares;
     }
+
+    this.container = new IOCContainer(options.container);
   }
 
   /**
@@ -77,6 +88,7 @@ export abstract class BuildContext {
     this.authMode = "error";
     this.pubSub = new PubSub();
     this.globalMiddlewares = [];
+    this.container = new IOCContainer();
   }
 }
 

--- a/src/utils/container.ts
+++ b/src/utils/container.ts
@@ -1,7 +1,3 @@
-/*
- * Special thanks for @pleerock for parts of this code :)
- */
-
 import { ResolverData } from "../interfaces";
 
 export type SupportedType<T> = { new (...args: any[]): T } | Function;
@@ -13,23 +9,6 @@ export interface ContainerType {
 export type ContainerGetter<TContext extends object> = (
   resolverData: ResolverData<TContext>,
 ) => ContainerType;
-
-/**
- * Container options.
- */
-export interface UseContainerOptions {
-  /**
-   * If set to true, then default container will be used in the case
-   * if given container haven't returned anything.
-   */
-  fallback?: boolean;
-
-  /**
-   * If set to true, then default container will be used in the case
-   * if given container thrown an exception.
-   */
-  fallbackOnErrors?: boolean;
-}
 
 /**
  * Container to be used by this library for inversion control.
@@ -50,87 +29,28 @@ class DefaultContainer {
   }
 }
 
-export abstract class IOCContainer {
-  private static userContainer?: ContainerType;
-  private static userContainerGetter?: ContainerGetter<any>;
-  private static userContainerOptions: UseContainerOptions;
-  private static defaultContainer = new DefaultContainer();
+export class IOCContainer {
+  private container: ContainerType | undefined;
+  private containerGetter: ContainerGetter<any> | undefined;
+  private defaultContainer = new DefaultContainer();
 
-  /**
-   * Sets the container to the basic, default one.
-   * Used mainly for testing purposes.
-   */
-  static restoreDefault() {
-    this.userContainer = undefined;
-    this.userContainerGetter = undefined;
-    this.userContainerOptions = {};
-    this.defaultContainer = new DefaultContainer();
-  }
-
-  /**
-   * Sets container to be used by this library.
-   */
-  static useContainer(iocContainer: ContainerType, options: UseContainerOptions = {}) {
-    this.userContainer = iocContainer;
-    this.userContainerGetter = undefined;
-    this.userContainerOptions = options;
-  }
-
-  /**
-   * Sets container getter function to be used by this library.
-   */
-  static useContainerGetter(
-    containerGetter: ContainerGetter<any>,
-    options: UseContainerOptions = {},
-  ) {
-    this.userContainer = undefined;
-    this.userContainerGetter = containerGetter;
-    this.userContainerOptions = options;
-  }
-
-  /**
-   * Gets the class instance from IOC container used by this library.
-   */
-  static getInstance<T = any>(someClass: SupportedType<T>, resolverData: ResolverData<any>): T {
-    const container = this.userContainerGetter
-      ? this.userContainerGetter(resolverData)
-      : this.userContainer;
-
-    if (container) {
-      try {
-        const instance = container.get(someClass, resolverData);
-        if (instance) {
-          return instance;
-        }
-
-        if (!this.userContainerOptions || !this.userContainerOptions.fallback) {
-          return instance;
-        }
-      } catch (error) {
-        if (!this.userContainerOptions || !this.userContainerOptions.fallbackOnErrors) {
-          throw error;
-        }
-      }
+  constructor(iocContainerOrContainerGetter?: ContainerType | ContainerGetter<any>) {
+    if (
+      iocContainerOrContainerGetter &&
+      "get" in iocContainerOrContainerGetter &&
+      typeof iocContainerOrContainerGetter.get === "function"
+    ) {
+      this.container = iocContainerOrContainerGetter;
+    } else if (typeof iocContainerOrContainerGetter === "function") {
+      this.containerGetter = iocContainerOrContainerGetter;
     }
-    return this.defaultContainer.get<T>(someClass);
   }
-}
 
-export function useContainer(iocContainer: ContainerType, options?: UseContainerOptions): void;
-export function useContainer<TContext extends object>(
-  containerGetter: ContainerGetter<TContext>,
-  options?: UseContainerOptions,
-): void;
-export function useContainer<TContext extends object>(
-  iocContainerOrGetFromResolverData: ContainerType | ContainerGetter<TContext>,
-  options?: UseContainerOptions,
-) {
-  if (
-    "get" in iocContainerOrGetFromResolverData &&
-    typeof iocContainerOrGetFromResolverData.get === "function"
-  ) {
-    IOCContainer.useContainer(iocContainerOrGetFromResolverData, options);
-  } else if (typeof iocContainerOrGetFromResolverData === "function") {
-    IOCContainer.useContainerGetter(iocContainerOrGetFromResolverData, options);
+  getInstance<T = any>(someClass: SupportedType<T>, resolverData: ResolverData<any>): T {
+    const container = this.containerGetter ? this.containerGetter(resolverData) : this.container;
+    if (!container) {
+      return this.defaultContainer.get<T>(someClass);
+    }
+    return container.get(someClass, resolverData);
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { buildSchema, buildSchemaSync, BuildSchemaOptions } from "./buildSchema";
 export { buildTypeDefsAndResolvers } from "./buildTypeDefsAndResolvers";
 export { emitSchemaDefinitionFile, emitSchemaDefinitionFileSync } from "./emitSchemaDefinitionFile";
-export { useContainer, ContainerType, ContainerGetter, UseContainerOptions } from "./container";
+export { ContainerType, ContainerGetter } from "./container";

--- a/tests/functional/resolvers.ts
+++ b/tests/functional/resolvers.ts
@@ -49,7 +49,6 @@ import {
   WrongNullableListOptionError,
 } from "../../src";
 import { getMetadataStorage } from "../../src/metadata/getMetadataStorage";
-import { IOCContainer } from "../../src/utils/container";
 import { getSchemaInfo } from "../helpers/getSchemaInfo";
 import { getInnerTypeOfNonNullableType } from "../helpers/getInnerFieldType";
 
@@ -1891,14 +1890,13 @@ describe("Resolvers", () => {
     });
 
     it("should get child class instance when calling base resolver handler", async () => {
-      IOCContainer.getInstance = jest.fn();
       const query = `query {
         prefixQuery(arg: true)
       }`;
 
       await graphql(schema, query);
 
-      expect(IOCContainer.getInstance).toHaveBeenCalledWith(childResolver, expect.anything());
+      expect(thisVar).toBeInstanceOf(childResolver);
     });
   });
 });

--- a/tests/functional/typedefs-resolvers.ts
+++ b/tests/functional/typedefs-resolvers.ts
@@ -43,7 +43,6 @@ import {
   Authorized,
   UseMiddleware,
   ResolversMap,
-  useContainer,
 } from "../../src";
 
 describe("buildTypeDefsAndResolvers", () => {
@@ -211,13 +210,12 @@ describe("buildTypeDefsAndResolvers", () => {
       }
     }
 
-    useContainer(Container);
-
     pubSub = new PubSub();
     ({ typeDefs, resolvers } = await buildTypeDefsAndResolvers({
       resolvers: [SampleResolver],
       authChecker: () => false,
       pubSub,
+      container: Container,
     }));
     schema = makeExecutableSchema({
       typeDefs,


### PR DESCRIPTION
Right now, the only way to register a 3rd party DI container is by using the global `useContainer` function. But this global way force us to share the same container between multiple `buildSchema` calls and multiple schemas will call in runtime the same container.

This PR change this API and make the `container` to be passed as the `buildSchema` option:
```ts
import { Container } from "typedi"
import { buildSchema } from "type-graphql"

await buildSchema({
  resolvers,
  container: Container,
});
```
It is placed in build context like the rest of the `buildSchema` options.

This PR will allow to move toward #110 and multiple schemas support without any leaks between them.