### PR TITLE
fix: special root fields don't have __isTypeOf

### DIFF
--- a/src/utils/createResolversMap.ts
+++ b/src/utils/createResolversMap.ts
@@ -23,6 +23,10 @@ export function createResolversMap(schema: GraphQLSchema): ResolversMap {
           __isTypeOf: type.isTypeOf || undefined,
           ...generateFieldsResolvers(type.getFields()),
         };
+        if (typeName === 'Query' || typeName === 'Mutation' || typeName === 'Subscription') {
+          resolversMap[typeName] = generateFieldsResolvers(type.getFields());
+          return resolversMap;
+        }
       }
       if (type instanceof GraphQLInterfaceType) {
         resolversMap[typeName] = {


### PR DESCRIPTION
I have a case where two different graphql parsers fail because of the root fields (in @graphql-modules)

Should this property really be exposed at all?