### PR TITLE
skip superfluous type conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Fixes
 - fix calling return type getter function `@Field(type => Foo)` before finishing module evaluation (allow for extending circular classes using `require`)
 - fix nullifying other custom method decorators - call the method on target instance, not the stored reference to original function (#247)
+- skip superfluous type-conversion. (#229)
 
 ## v0.16.0
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## Fixes
 - fix calling return type getter function `@Field(type => Foo)` before finishing module evaluation (allow for extending circular classes using `require`)
 - fix nullifying other custom method decorators - call the method on target instance, not the stored reference to original function (#247)
-- skip superfluous type-conversion. (#229)
+- Prevent unnecessary conversion of a object that is already of the requested typ, to avoid constructor side-effects (#229)
 
 ## v0.16.0
 ### Features

--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ PRs are welcome, but first check, test and build your code before committing it.
 * Use commit rules: For more information checkout this [commit rule guide](https://gist.github.com/stephenparish/9941e89d80e2bc58a153).
 * [Allowing changes to a pull request branch created from a fork](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/)
 
-If you want to add a new big feature, please create a proposal first, where we can discuss the idea and implementation details. This will prevent wasting of your time if the PR be rejected.
+If you want to add a new big feature, please create a proposal first, where we can discuss the idea and implementation details. This will prevent wasting of your time if the PR is rejected.

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -83,7 +83,7 @@ export function convertToType(Target: any, data?: object): object | undefined {
     return;
   }
   // Prevent unecessary conversion
-  if (data instanceof Target) {
+  if (typeof Target === "object" || data instanceof Target) {
     return data;
   }
   // skip converting scalars (object scalar mostly)

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -82,6 +82,10 @@ export function convertToType(Target: any, data?: object): object | undefined {
   if (data == null) {
     return;
   }
+  // Prevent unecessary conversion
+  if (data instanceof Target) {
+    return data;
+  }
   // skip converting scalars (object scalar mostly)
   if (Target instanceof GraphQLScalarType) {
     return data;

--- a/tests/units/convertToType.ts
+++ b/tests/units/convertToType.ts
@@ -1,0 +1,35 @@
+import { convertToType } from "../../src/helpers/types";
+
+describe("convertToType", () => {
+  let globalCounter = 0;
+
+  class SampleTarget {
+    constructor(public test: number) {
+      globalCounter++;
+    }
+  }
+
+  beforeEach(() => {
+    globalCounter = 0;
+  });
+
+  it("should properly convert a object to the defined target", async () => {
+    const testObject = {
+      test: 4,
+    };
+
+    const convertedObject = convertToType(SampleTarget, testObject);
+    expect(convertedObject).toBeDefined();
+    expect(convertedObject).toHaveProperty("test");
+    expect(globalCounter).toBe(1);
+  });
+
+  it("should not convert a object to the defined target if it is already instance of that Target", async () => {
+    const testObject = new SampleTarget(4);
+
+    const convertedObject = convertToType(SampleTarget, testObject);
+    expect(convertedObject).toBeDefined();
+    expect(convertedObject).toHaveProperty("test");
+    expect(globalCounter).toBe(1);
+  });
+});

--- a/tests/units/convertToType.ts
+++ b/tests/units/convertToType.ts
@@ -1,4 +1,5 @@
 import { convertToType } from "../../src/helpers/types";
+import { Expose } from "class-transformer";
 
 describe("convertToType", () => {
   let globalCounter = 0;
@@ -18,18 +19,24 @@ describe("convertToType", () => {
       test: 4,
     };
 
+    expect(globalCounter).toBe(0);
     const convertedObject = convertToType(SampleTarget, testObject);
     expect(convertedObject).toBeDefined();
+    expect(convertedObject instanceof SampleTarget).toBe(true);
     expect(convertedObject).toHaveProperty("test");
+    expect((convertedObject as SampleTarget).test).toEqual(4);
     expect(globalCounter).toBe(1);
   });
 
   it("should not convert a object to the defined target if it is already instance of that Target", async () => {
     const testObject = new SampleTarget(4);
 
+    expect(globalCounter).toBe(1);
     const convertedObject = convertToType(SampleTarget, testObject);
     expect(convertedObject).toBeDefined();
+    expect(convertedObject instanceof SampleTarget).toBe(true);
     expect(convertedObject).toHaveProperty("test");
+    expect((convertedObject as SampleTarget).test).toEqual(4);
     expect(globalCounter).toBe(1);
   });
 });

--- a/tests/units/convertToType.ts
+++ b/tests/units/convertToType.ts
@@ -1,5 +1,4 @@
 import { convertToType } from "../../src/helpers/types";
-import { Expose } from "class-transformer";
 
 describe("convertToType", () => {
   let globalCounter = 0;


### PR DESCRIPTION
This PR fixes Constructor-Side-Effects that can occur when a type is converted even though it is not necessary.
Closes #229 