### PR TITLE
Add types field at package.json, because we do not use default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 <!-- here goes all the unreleased changes descriptions -->
 ### Features
 - add support for emitting schema file in not existing directory (#269)
+### Fixes
+- fix typings discovery support for WebStorm (#276)
 ### Others
 - **Breaking Change**: drop support for Node.js v6 (end of LTS in April 2019)
 

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     ]
   },
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "readmeFilename": "README.md",
   "description": "Create GraphQL schema and resolvers with TypeScript, using classes and decorators!",
   "license": "MIT",


### PR DESCRIPTION
@19majkel94, I migrated to 0.17 and lost typescripts support at WebStorm. This pull should fix the issue.