### PR TITLE
Add `subscribe` option to `Subscription` decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- here goes all the unreleased changes descriptions -->
 ## Features
 - add support for creating custom parameter decorators (#329)
+- allow to provide custom `subscribe` function in `@Subscription` decorator (#328)
 
 ## v0.17.3
 ### Features

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -56,7 +56,7 @@ class SampleResolver {
 
 You can also provide a custom subscription logic, if you pass it to the `subscribe` option. The could become useful, if you want to use the Prisma subscription functionality or something similar.
 
-This function should return an`AsyncIterator<any>` type.
+This function should return an `AsyncIterator<any>` type.
 
 ```typescript
 class SampleResolver {

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -54,6 +54,30 @@ class SampleResolver {
 }
 ```
 
+You can also provide a custom subscription logic, if you pass it to the `subscribe` option. The could become useful, if you want to use the Prisma subscription functionality or something similar.
+
+This function should return an`AsyncIterator<any>` type.
+
+```typescript
+class SampleResolver {
+  // ...
+  @Subscription({
+    topics: "",
+    subscribe: ({ args, context }) =>
+      context.prisma.$subscribe.users({ mutation_in: [args.mutationType] }),
+  })
+  newNotification(): Notification {
+    // ...
+  }
+}
+```
+
+Please consider, that the `subscribe` option has 2 restrictions:
+
+- if you are using this option, `topics` and `filter` become useless. If you still need a filter function, you can use the `withFilter` function from the `graphql-subscriptions` package.
+- as this option does not have any access to class properties, DI might not be easy or even impossible.  
+  <br>
+
 Now we can implement the subscription resolver. It will receive the payload from a triggered topic of the pubsub system using the `@Root()` decorator. There, we can transform it to the returned shape.
 
 ```typescript

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -54,17 +54,17 @@ class SampleResolver {
 }
 ```
 
-You can also provide a custom subscription logic, if you pass it to the `subscribe` option. The could become useful, if you want to use the Prisma subscription functionality or something similar.
+We can also provide a custom subscription logic which might be useful, e.g. if we want to use the Prisma subscription functionality or something similar.
 
-This function should return an `AsyncIterator<any>` type.
+All we need to do is to use the the `subscribe` option which should be a function that returns an `AsyncIterator`. Example using Prisma client subscription feature:
 
 ```typescript
 class SampleResolver {
   // ...
   @Subscription({
-    topics: "",
-    subscribe: ({ args, context }) =>
-      context.prisma.$subscribe.users({ mutation_in: [args.mutationType] }),
+    subscribe: ({ args, context }) => {
+      return context.prisma.$subscribe.users({ mutation_in: [args.mutationType] });
+    },
   })
   newNotification(): Notification {
     // ...
@@ -72,11 +72,7 @@ class SampleResolver {
 }
 ```
 
-Please consider, that the `subscribe` option has 2 restrictions:
-
-- if you are using this option, `topics` and `filter` become useless. If you still need a filter function, you can use the `withFilter` function from the `graphql-subscriptions` package.
-- as this option does not have any access to class properties, DI might not be easy or even impossible.  
-  <br>
+> Be aware that we can't mix the `subscribe` option with the `topics` and `filter` options. If the filtering is still needed, we can use the [`withFilter` function](https://github.com/apollographql/graphql-subscriptions#filters) from the `graphql-subscriptions` package.
 
 Now we can implement the subscription resolver. It will receive the payload from a triggered topic of the pubsub system using the `@Root()` decorator. There, we can transform it to the returned shape.
 

--- a/src/decorators/Subscription.ts
+++ b/src/decorators/Subscription.ts
@@ -8,10 +8,12 @@ import { getMetadataStorage } from "../metadata/getMetadataStorage";
 import { getResolverMetadata } from "../helpers/resolver-metadata";
 import { getTypeDecoratorParams } from "../helpers/decorators";
 import { MissingSubscriptionTopicsError } from "../errors";
+import { ResolverFn } from "graphql-subscriptions";
 
 export interface SubscriptionOptions extends AdvancedOptions {
   topics: string | string[] | SubscriptionTopicFunc;
   filter?: SubscriptionFilterFunc;
+  subscribe?: ResolverFn;
 }
 
 export function Subscription(options: SubscriptionOptions): MethodDecorator;
@@ -34,6 +36,7 @@ export function Subscription(
       ...metadata,
       topics: subscriptionOptions.topics,
       filter: subscriptionOptions.filter,
+      subscribe: subscriptionOptions.subscribe,
     });
   };
 }

--- a/src/decorators/Subscription.ts
+++ b/src/decorators/Subscription.ts
@@ -1,3 +1,5 @@
+import { ResolverFn } from "graphql-subscriptions";
+
 import {
   ReturnTypeFunc,
   AdvancedOptions,
@@ -8,13 +10,18 @@ import { getMetadataStorage } from "../metadata/getMetadataStorage";
 import { getResolverMetadata } from "../helpers/resolver-metadata";
 import { getTypeDecoratorParams } from "../helpers/decorators";
 import { MissingSubscriptionTopicsError } from "../errors";
-import { ResolverFn } from "graphql-subscriptions";
+import { MergeExclusive } from "../utils/types";
 
-export interface SubscriptionOptions extends AdvancedOptions {
+interface PubSubOptions {
   topics: string | string[] | SubscriptionTopicFunc;
   filter?: SubscriptionFilterFunc;
-  subscribe?: ResolverFn;
 }
+
+interface SubscribeOptions {
+  subscribe: ResolverFn;
+}
+
+export type SubscriptionOptions = AdvancedOptions & MergeExclusive<PubSubOptions, SubscribeOptions>;
 
 export function Subscription(options: SubscriptionOptions): MethodDecorator;
 export function Subscription(
@@ -25,18 +32,18 @@ export function Subscription(
   returnTypeFuncOrOptions: ReturnTypeFunc | SubscriptionOptions,
   maybeOptions?: SubscriptionOptions,
 ): MethodDecorator {
-  const { options, returnTypeFunc } = getTypeDecoratorParams(returnTypeFuncOrOptions, maybeOptions);
+  const params = getTypeDecoratorParams(returnTypeFuncOrOptions, maybeOptions);
+  const options = params.options as SubscriptionOptions;
   return (prototype, methodName) => {
-    const metadata = getResolverMetadata(prototype, methodName, returnTypeFunc, options);
-    const subscriptionOptions = options as SubscriptionOptions;
+    const metadata = getResolverMetadata(prototype, methodName, params.returnTypeFunc, options);
     if (Array.isArray(options.topics) && options.topics.length === 0) {
       throw new MissingSubscriptionTopicsError(metadata.target, metadata.methodName);
     }
     getMetadataStorage().collectSubscriptionHandlerMetadata({
       ...metadata,
-      topics: subscriptionOptions.topics,
-      filter: subscriptionOptions.filter,
-      subscribe: subscriptionOptions.subscribe,
+      topics: options.topics,
+      filter: options.filter,
+      subscribe: options.subscribe,
     });
   };
 }

--- a/src/metadata/definitions/resolver-metadata.ts
+++ b/src/metadata/definitions/resolver-metadata.ts
@@ -8,6 +8,7 @@ import {
 import { ParamMetadata } from "./param-metadata";
 import { Middleware } from "../../interfaces/Middleware";
 import { Complexity } from "../../interfaces";
+import { ResolverFn } from "graphql-subscriptions";
 
 export interface BaseResolverMetadata {
   methodName: string;
@@ -39,6 +40,7 @@ export interface FieldResolverMetadata extends BaseResolverMetadata {
 export interface SubscriptionResolverMetadata extends ResolverMetadata {
   topics: string | string[] | SubscriptionTopicFunc;
   filter: SubscriptionFilterFunc | undefined;
+  subscribe: ResolverFn | undefined;
 }
 
 export interface ResolverClassMetadata {

--- a/src/metadata/definitions/resolver-metadata.ts
+++ b/src/metadata/definitions/resolver-metadata.ts
@@ -1,3 +1,5 @@
+import { ResolverFn } from "graphql-subscriptions";
+
 import {
   TypeValueThunk,
   TypeOptions,
@@ -8,7 +10,6 @@ import {
 import { ParamMetadata } from "./param-metadata";
 import { Middleware } from "../../interfaces/Middleware";
 import { Complexity } from "../../interfaces";
-import { ResolverFn } from "graphql-subscriptions";
 
 export interface BaseResolverMetadata {
   methodName: string;
@@ -38,7 +39,7 @@ export interface FieldResolverMetadata extends BaseResolverMetadata {
 }
 
 export interface SubscriptionResolverMetadata extends ResolverMetadata {
-  topics: string | string[] | SubscriptionTopicFunc;
+  topics: string | string[] | SubscriptionTopicFunc | undefined;
   filter: SubscriptionFilterFunc | undefined;
   subscribe: ResolverFn | undefined;
 }

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -465,7 +465,7 @@ export abstract class SchemaGenerator {
           return pubSub.asyncIterator(topics);
         };
       } else {
-        const topics = handler.topics;
+        const topics = handler.topics!;
         pubSubIterator = () => pubSub.asyncIterator(topics);
       }
 

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -448,6 +448,11 @@ export abstract class SchemaGenerator {
         return fields;
       }
 
+      if (handler.subscribe) {
+        fields[handler.schemaName].subscribe = handler.subscribe;
+        return fields;
+      }
+
       let pubSubIterator: ResolverFn;
       if (typeof handler.topics === "function") {
         const getTopics = handler.topics;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,10 @@
+// `Without` and `MergeExclusive` copied from `sindresorhus/type-fest`
+// https://github.com/sindresorhus/type-fest/blob/c6a3d8c2603e9d6b8f20edb0157faae15548cd5b/source/merge-exclusive.d.ts
+
+export type Without<FirstType, SecondType> = {
+  [KeyType in Exclude<keyof FirstType, keyof SecondType>]?: never
+};
+
+export type MergeExclusive<FirstType, SecondType> = (FirstType | SecondType) extends object
+  ? (Without<FirstType, SecondType> & SecondType) | (Without<SecondType, FirstType> & FirstType)
+  : FirstType | SecondType;

--- a/tests/functional/subscriptions.ts
+++ b/tests/functional/subscriptions.ts
@@ -214,10 +214,7 @@ describe("Subscriptions", () => {
           return { value };
         }
 
-        @Subscription({
-          topics: "",
-          subscribe: () => localPubSub.asyncIterator(CUSTOM_SUBSCRIBE_TOPIC),
-        })
+        @Subscription({ subscribe: () => localPubSub.asyncIterator(CUSTOM_SUBSCRIBE_TOPIC) })
         customSubscribeSubscription(@Root() value: number): SampleObject {
           return { value };
         }


### PR DESCRIPTION
As described in #327, this PR adds a `subscribe` option to the `Subscription` decorator. This option allows it to use custom subscription systems, e.g. the one Prisma is providing.