### PR TITLE
WIP: Resolver builder argument

### DIFF
--- a/examples/custom-resolver-builder/auth-guard.decorator.ts
+++ b/examples/custom-resolver-builder/auth-guard.decorator.ts
@@ -1,0 +1,10 @@
+import "reflect-metadata";
+
+export const AuthGuard = (target: Object, propertyKey: string) => {
+  Reflect.defineMetadata(
+    "AUTHORIZATION",
+    true,
+    target.constructor,
+    propertyKey,
+  );
+};

--- a/examples/custom-resolver-builder/index.ts
+++ b/examples/custom-resolver-builder/index.ts
@@ -1,0 +1,46 @@
+import { buildSchema } from "../../src/utils";
+import { RecipeResolver } from "./recipe-resolver";
+import { GraphQLFieldResolver } from "graphql";
+import { BaseResolverMetadata } from "../../src/metadata/definitions";
+import { ApolloServer, AuthenticationError } from "apollo-server";
+import "reflect-metadata";
+
+
+async function bootstrap() {
+  // simple custom resolver builder
+  function resolverBuilder(metadata: BaseResolverMetadata): GraphQLFieldResolver<any, any, any> {
+    return (root, args, { req }) => {
+      const authMetadata = Reflect.getMetadata(
+        "AUTHORIZATION",
+        metadata.target,
+        metadata.methodName,
+      );
+
+      if (authMetadata) {
+        if (!req.headers.authorized || req.headers.authorized !== "true") {
+          throw new AuthenticationError('Must set Authorized header to "true".');
+        }
+      }
+
+      const targetInstance = new (metadata.target as any);
+      return targetInstance[metadata.methodName].apply(targetInstance);
+    };
+  }
+
+  // build TypeGraphQL executable schema
+  const schema = await buildSchema({
+    resolvers: [RecipeResolver],
+    resolverBuilder,
+  });
+
+  // create and run apollo server
+  const server = new ApolloServer({
+    schema,
+    playground: true,
+    context: context => context,
+  });
+  const { url } = await server.listen(4000);
+  console.log(`Server is running, GraphQL Playground available at ${url}`);
+}
+
+bootstrap();

--- a/examples/custom-resolver-builder/recipe-resolver.ts
+++ b/examples/custom-resolver-builder/recipe-resolver.ts
@@ -1,0 +1,20 @@
+import { Resolver, Query } from "../../src";
+
+import { Recipe } from "./recipe-type";
+import { AuthGuard } from "./auth-guard.decorator";
+
+@Resolver(of => Recipe)
+export class RecipeResolver {
+  private readonly recipe: Recipe = {
+    description: "Desc 1",
+    title: "Recipe 1",
+    ratings: [0, 3, 1],
+    creationDate: new Date("2018-04-11"),
+  };
+
+  @AuthGuard
+  @Query(returns => Recipe, { name: "recipe", nullable: true })
+  getRecipe(): Recipe {
+    return this.recipe;
+  }
+}

--- a/examples/custom-resolver-builder/recipe-type.ts
+++ b/examples/custom-resolver-builder/recipe-type.ts
@@ -1,0 +1,16 @@
+import { Field, ObjectType, Int, Float } from "../../src";
+
+@ObjectType({ description: "Object representing cooking recipe" })
+export class Recipe {
+  @Field()
+  title: string;
+
+  @Field({ nullable: true, description: "The recipe description with preparation info" })
+  description?: string;
+
+  @Field(type => [Int])
+  ratings: number[];
+
+  @Field()
+  creationDate: Date;
+}

--- a/src/resolvers/create.ts
+++ b/src/resolvers/create.ts
@@ -20,23 +20,28 @@ export function createHandlerResolver(
     pubSub,
     globalMiddlewares,
     container,
+    resolverBuilder,
   } = BuildContext;
-  const middlewares = globalMiddlewares.concat(resolverMetadata.middlewares!);
-  applyAuthChecker(middlewares, authMode, authChecker, resolverMetadata.roles);
+  if (!resolverBuilder) {
+    const middlewares = globalMiddlewares.concat(resolverMetadata.middlewares!);
+    applyAuthChecker(middlewares, authMode, authChecker, resolverMetadata.roles);
 
-  return async (root, args, context, info) => {
-    const resolverData: ResolverData<any> = { root, args, context, info };
-    const targetInstance = container.getInstance(resolverMetadata.target, resolverData);
-    return applyMiddlewares(container, resolverData, middlewares, async () => {
-      const params: any[] = await getParams(
-        resolverMetadata.params!,
-        resolverData,
-        globalValidate,
-        pubSub,
-      );
-      return targetInstance[resolverMetadata.methodName].apply(targetInstance, params);
-    });
-  };
+    return async (root, args, context, info) => {
+      const resolverData: ResolverData<any> = { root, args, context, info };
+      const targetInstance = container.getInstance(resolverMetadata.target, resolverData);
+      return applyMiddlewares(container, resolverData, middlewares, async () => {
+        const params: any[] = await getParams(
+          resolverMetadata.params!,
+          resolverData,
+          globalValidate,
+          pubSub,
+        );
+        return targetInstance[resolverMetadata.methodName].apply(targetInstance, params);
+      });
+    };
+  } else {
+    return resolverBuilder(resolverMetadata);
+  }
 }
 
 export function createAdvancedFieldResolver(

--- a/src/schema/build-context.ts
+++ b/src/schema/build-context.ts
@@ -1,10 +1,11 @@
-import { GraphQLScalarType } from "graphql";
+import { GraphQLFieldResolver, GraphQLScalarType } from "graphql";
 import { ValidatorOptions } from "class-validator";
 import { PubSubEngine, PubSub, PubSubOptions } from "graphql-subscriptions";
 
-import { AuthChecker, AuthMode } from "../interfaces";
+import { AuthChecker, AuthMode, ClassType } from "../interfaces";
 import { Middleware } from "../interfaces/Middleware";
 import { ContainerType, ContainerGetter, IOCContainer } from "../utils/container";
+import { BaseResolverMetadata } from "../metadata/definitions";
 
 export type DateScalarMode = "isoDate" | "timestamp";
 
@@ -30,6 +31,7 @@ export interface BuildContextOptions {
    * Default value for type decorators, like `@Field({ nullable: true })`
    */
   nullableByDefault?: boolean;
+  resolverBuilder?: (metadata: BaseResolverMetadata) => GraphQLFieldResolver<any, any, any>;
 }
 
 export abstract class BuildContext {
@@ -42,6 +44,7 @@ export abstract class BuildContext {
   static globalMiddlewares: Array<Middleware<any>>;
   static container: IOCContainer;
   static nullableByDefault: boolean;
+  static resolverBuilder?: (metadata: BaseResolverMetadata) => GraphQLFieldResolver<any, any, any>;
 
   /**
    * Set static fields with current building context data
@@ -83,6 +86,10 @@ export abstract class BuildContext {
 
     if (options.nullableByDefault !== undefined) {
       this.nullableByDefault = options.nullableByDefault;
+    }
+
+    if (options.resolverBuilder !== undefined) {
+      this.resolverBuilder = options.resolverBuilder;
     }
   }
 

--- a/src/utils/buildSchema.ts
+++ b/src/utils/buildSchema.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema } from "graphql";
+import { GraphQLFieldResolver, GraphQLSchema } from "graphql";
 import { Options as PrintSchemaOptions } from "graphql/utilities/schemaPrinter";
 import * as path from "path";
 
@@ -9,6 +9,8 @@ import {
   emitSchemaDefinitionFile,
   defaultPrintSchemaOptions,
 } from "./emitSchemaDefinitionFile";
+import { ClassType } from "../interfaces";
+import { BaseResolverMetadata } from "../metadata/definitions";
 
 interface EmitSchemaFileOptions extends PrintSchemaOptions {
   path?: string;
@@ -23,7 +25,13 @@ export interface BuildSchemaOptions extends SchemaGeneratorOptions {
    * or `true` for the default `./schema.gql` one
    */
   emitSchemaFile?: string | boolean | EmitSchemaFileOptions;
+
+  /**
+   * Resolver builder function that overrides generating resolvers for framework integrations
+   */
+  resolverBuilder?: (metadata: BaseResolverMetadata) => GraphQLFieldResolver<any, any, any>;
 }
+
 export async function buildSchema(options: BuildSchemaOptions): Promise<GraphQLSchema> {
   loadResolvers(options);
   const schema = await SchemaGenerator.generateFromMetadata(options);


### PR DESCRIPTION
It's just for showing the idea described here:
https://github.com/19majkel94/type-graphql/issues/135#issuecomment-487503933

This pull request adds `resolverBuilder` parameter to `buildSchema`. It overrides TypeGraphQL's resolver creation function with the one passed in this parameter and allows frameworks to wrap resolver with their own execution context.