### PR TITLE
Fix typo depreciation/deprecation

### DIFF
--- a/src/decorators/types.ts
+++ b/src/decorators/types.ts
@@ -58,7 +58,7 @@ export interface ResolveTypeOptions<TSource = any, TContext = any> {
 }
 export type BasicOptions = DecoratorTypeOptions & DescriptionOptions;
 export type AdvancedOptions = BasicOptions &
-  DepreciationOptions &
+  DeprecationOptions &
   SchemaNameOptions &
   ComplexityOptions;
 

--- a/src/decorators/types.ts
+++ b/src/decorators/types.ts
@@ -38,7 +38,7 @@ export interface TypeOptions extends DecoratorTypeOptions {
 export interface DescriptionOptions {
   description?: string;
 }
-export interface DepreciationOptions {
+export interface DeprecationOptions {
   deprecationReason?: string;
 }
 export interface ValidateOptions {


### PR DESCRIPTION
Tests/typechecks seem to be passing.

Technically someone might refer to the interface externally and could be considered a breaking change, but I would guess this is unlikely?