### PR TITLE
docs: getting started update snippet deprecation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,7 +69,7 @@ class RecipeResolver {
 
   @Query(returns => Recipe)
   async recipe(@Arg("id") id: string) {
-    const recipe = await this.recipeService.findById(id);
+    const recipe = await this.recipeService.find(id);
     if (recipe === undefined) {
       throw new RecipeNotFoundError(id);
     }


### PR DESCRIPTION
findById has been deprecated in TypeORM and the recommendation is to simply use `find(id)` now.