### PR TITLE
feat: Types transformation utils

### DIFF
--- a/src/helpers/inherit-metedata.ts
+++ b/src/helpers/inherit-metedata.ts
@@ -1,0 +1,186 @@
+// Inspired by @nestjs/mapped-types
+import { ClassType } from "../interfaces";
+
+export function applyIsOptionalDecorator(targetClass: Function, propertyKey: string) {
+  if (!isClassValidatorAvailable()) {
+    return;
+  }
+  const classValidator: typeof import("class-validator") = require("class-validator");
+  const decoratorFactory = classValidator.IsOptional();
+  decoratorFactory(targetClass.prototype, propertyKey);
+}
+
+export function inheritValidationMetadata(
+  parentClass: ClassType<any>,
+  targetClass: Function,
+  isPropertyInherited?: (key: string) => boolean,
+) {
+  if (!isClassValidatorAvailable()) {
+    return;
+  }
+  try {
+    const classValidator: typeof import("class-validator") = require("class-validator");
+    const metadataStorage: import("class-validator").MetadataStorage = (classValidator as any)
+      .getMetadataStorage
+      ? (classValidator as any).getMetadataStorage()
+      : classValidator.getFromContainer(classValidator.MetadataStorage);
+
+    const getTargetValidationMetadatasArgs = [parentClass, null!, false, false];
+    const targetMetadata: ReturnType<
+      typeof metadataStorage.getTargetValidationMetadatas
+    > = (metadataStorage.getTargetValidationMetadatas as Function)(
+      ...getTargetValidationMetadatasArgs,
+    );
+    targetMetadata
+      .filter(({ propertyName }) => !isPropertyInherited || isPropertyInherited(propertyName))
+      .map(value => {
+        const originalType = Reflect.getMetadata(
+          "design:type",
+          parentClass.prototype,
+          value.propertyName,
+        );
+        if (originalType) {
+          // @ts-ignore
+          Reflect.defineMetadata(
+            "design:type",
+            originalType,
+            targetClass.prototype,
+            value.propertyName,
+          );
+        }
+
+        metadataStorage.addValidationMetadata({
+          ...value,
+          target: targetClass,
+        });
+        return value.propertyName;
+      });
+  } catch (err) {
+    if (err.code !== "EEXIST") {
+      throw err;
+    }
+  }
+}
+
+type TransformMetadataKey =
+  | "_excludeMetadatas"
+  | "_exposeMetadatas"
+  | "_typeMetadatas"
+  | "_transformMetadatas";
+
+export function inheritTransformationMetadata(
+  parentClass: ClassType<any>,
+  targetClass: Function,
+  isPropertyInherited?: (key: string) => boolean,
+) {
+  if (!isClassTransformerAvailable()) {
+    return;
+  }
+  try {
+    const transformMetadataKeys: TransformMetadataKey[] = [
+      "_excludeMetadatas",
+      "_exposeMetadatas",
+      "_transformMetadatas",
+      "_typeMetadatas",
+    ];
+    transformMetadataKeys.forEach(key =>
+      inheritTransformerMetadata(key, parentClass, targetClass, isPropertyInherited),
+    );
+  } catch (err) {
+    if (err.code !== "EEXIST") {
+      throw err;
+    }
+  }
+}
+
+function inheritTransformerMetadata(
+  key: TransformMetadataKey,
+  parentClass: ClassType<any>,
+  targetClass: Function,
+  isPropertyInherited?: (key: string) => boolean,
+) {
+  let classTransformer: any;
+  try {
+    /** "class-transformer" >= v0.3.x */
+    classTransformer = require("class-transformer/cjs/storage");
+  } catch {
+    /** "class-transformer" <= v0.3.x */
+    classTransformer = require("class-transformer/storage");
+  }
+  const metadataStorage /*: typeof import('class-transformer/types/storage').defaultMetadataStorage */ =
+    classTransformer.defaultMetadataStorage;
+
+  while (parentClass && parentClass !== Object) {
+    if (metadataStorage[key].has(parentClass)) {
+      const metadataMap = metadataStorage[key] as Map<Function, Map<string, any>>;
+      const parentMetadata = metadataMap.get(parentClass);
+
+      const targetMetadataEntries: Iterable<[string, any]> = Array.from(parentMetadata!.entries())
+        .filter(([keyInEntries]) => !isPropertyInherited || isPropertyInherited(keyInEntries))
+        .map(([keyInEntries, metadata]) => {
+          if (Array.isArray(metadata)) {
+            // "_transformMetadatas" is an array of elements
+            const targetMetadata = metadata.map(item => ({
+              ...item,
+              target: targetClass,
+            }));
+            return [keyInEntries, targetMetadata];
+          }
+          return [keyInEntries, { ...metadata, target: targetClass }];
+        });
+
+      if (metadataMap.has(targetClass)) {
+        const existingRules = metadataMap.get(targetClass)!.entries();
+        metadataMap.set(targetClass, new Map([...existingRules, ...targetMetadataEntries]));
+      } else {
+        metadataMap.set(targetClass, new Map(targetMetadataEntries));
+      }
+    }
+    parentClass = Object.getPrototypeOf(parentClass);
+  }
+}
+
+function isClassValidatorAvailable() {
+  try {
+    require("class-validator");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isClassTransformerAvailable() {
+  try {
+    require("class-transformer");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function inheritPropertyInitializers(
+  target: Record<string, any>,
+  sourceClass: ClassType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isPropertyInherited = (key: string) => true,
+) {
+  try {
+    const tempInstance = new sourceClass();
+    const propertyNames = Object.getOwnPropertyNames(tempInstance);
+
+    propertyNames
+      .filter(
+        propertyName =>
+          typeof tempInstance[propertyName] !== "undefined" &&
+          typeof target[propertyName] === "undefined",
+      )
+      .filter(propertyName => isPropertyInherited(propertyName))
+      .forEach(propertyName => {
+        target[propertyName] = tempInstance[propertyName];
+      });
+  } catch (err) {
+    if (err.code !== "EEXIST") {
+      throw err;
+    }
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,3 +11,4 @@ export {
   defaultPrintSchemaOptions,
 } from "./emitSchemaDefinitionFile";
 export { ContainerType, ContainerGetter } from "./container";
+export { PartialType, PickType, RequiredType, OmitType } from "./types-transformation";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,4 +11,10 @@ export {
   defaultPrintSchemaOptions,
 } from "./emitSchemaDefinitionFile";
 export { ContainerType, ContainerGetter } from "./container";
-export { PartialType, PickType, RequiredType, OmitType } from "./types-transformation";
+export {
+  PartialType,
+  PickType,
+  RequiredType,
+  OmitType,
+  IntersectionType,
+} from "./types-transformation";

--- a/src/utils/types-transformation.ts
+++ b/src/utils/types-transformation.ts
@@ -3,10 +3,7 @@ import { ClassType } from "../interfaces";
 import { getMetadataStorage } from "../metadata";
 
 export function PartialType<T>(BaseClass: ClassType<T>): ClassType<Partial<T>> {
-  class PartialClass {}
-  InputType({ isAbstract: true })(PartialClass);
-  ObjectType({ isAbstract: true })(PartialClass);
-  InterfaceType({ isAbstract: true })(PartialClass);
+  const PartialClass = abstractClass();
 
   const fields = getMetadataStorage().fields.filter(
     f => f.target === BaseClass || BaseClass.prototype instanceof f.target,
@@ -24,10 +21,7 @@ export function PartialType<T>(BaseClass: ClassType<T>): ClassType<Partial<T>> {
 }
 
 export function RequiredType<T>(BaseClass: ClassType<T>): ClassType<Required<T>> {
-  class RequiredClass {}
-  InputType({ isAbstract: true })(RequiredClass);
-  ObjectType({ isAbstract: true })(RequiredClass);
-  InterfaceType({ isAbstract: true })(RequiredClass);
+  const RequiredClass = abstractClass();
 
   const fields = getMetadataStorage().fields.filter(
     f => f.target === BaseClass || BaseClass.prototype instanceof f.target,
@@ -47,10 +41,7 @@ export function PickType<T, K extends keyof T>(
   BaseClass: ClassType<T>,
   ...pickFields: K[]
 ): ClassType<Pick<T, K>> {
-  class PickClass {}
-  InputType({ isAbstract: true })(PickClass);
-  ObjectType({ isAbstract: true })(PickClass);
-  InterfaceType({ isAbstract: true })(PickClass);
+  const PickClass = abstractClass();
 
   const fields = getMetadataStorage().fields.filter(
     f =>
@@ -71,10 +62,7 @@ export function OmitType<T, K extends keyof T>(
   BaseClass: ClassType<T>,
   ...omitFields: K[]
 ): ClassType<Omit<T, K>> {
-  class OmitClass {}
-  InputType({ isAbstract: true })(OmitClass);
-  ObjectType({ isAbstract: true })(OmitClass);
-  InterfaceType({ isAbstract: true })(OmitClass);
+  const OmitClass = abstractClass();
 
   const fields = getMetadataStorage().fields.filter(
     f =>
@@ -92,10 +80,7 @@ export function OmitType<T, K extends keyof T>(
 }
 
 export function IntersectionType<A, B>(BaseClassA: ClassType<A>, BaseClassB: ClassType<B>) {
-  class IntersectionClass {}
-  InputType({ isAbstract: true })(IntersectionClass);
-  ObjectType({ isAbstract: true })(IntersectionClass);
-  InterfaceType({ isAbstract: true })(IntersectionClass);
+  const IntersectionClass = abstractClass();
 
   const fields = getMetadataStorage().fields.filter(
     f =>
@@ -113,4 +98,17 @@ export function IntersectionType<A, B>(BaseClassA: ClassType<A>, BaseClassB: Cla
   });
 
   return IntersectionClass as ClassType<A & B>;
+}
+
+function abstractClass() {
+  class AbstractClass {}
+  InputType({ isAbstract: true })(AbstractClass);
+  ObjectType({ isAbstract: true })(AbstractClass);
+  InterfaceType({ isAbstract: true })(AbstractClass);
+  getMetadataStorage().collectArgsMetadata({
+    name: AbstractClass.name,
+    isAbstract: true,
+    target: AbstractClass,
+  });
+  return AbstractClass;
 }

--- a/src/utils/types-transformation.ts
+++ b/src/utils/types-transformation.ts
@@ -1,0 +1,92 @@
+import { ObjectType, InputType, InterfaceType } from "../decorators";
+import { ClassType } from "../interfaces";
+import { getMetadataStorage } from "../metadata";
+
+export function PartialType<T>(BaseClass: ClassType<T>): ClassType<Partial<T>> {
+  class PartialClass {}
+  InputType({ isAbstract: true })(PartialClass);
+  ObjectType({ isAbstract: true })(PartialClass);
+  InterfaceType({ isAbstract: true })(PartialClass);
+
+  const fields = getMetadataStorage().fields.filter(
+    f => f.target === BaseClass || BaseClass.prototype instanceof f.target,
+  );
+
+  fields.forEach(field => {
+    getMetadataStorage().collectClassFieldMetadata({
+      ...field,
+      typeOptions: { ...field.typeOptions, nullable: true },
+      target: PartialClass,
+    });
+  });
+
+  return PartialClass as ClassType<Partial<T>>;
+}
+
+export function RequiredType<T>(BaseClass: ClassType<T>): ClassType<Required<T>> {
+  class RequiredClass {}
+  InputType({ isAbstract: true })(RequiredClass);
+  ObjectType({ isAbstract: true })(RequiredClass);
+  InterfaceType({ isAbstract: true })(RequiredClass);
+
+  const fields = getMetadataStorage().fields.filter(
+    f => f.target === BaseClass || BaseClass.prototype instanceof f.target,
+  );
+
+  fields.forEach(field => {
+    getMetadataStorage().collectClassFieldMetadata({
+      ...field,
+      typeOptions: { ...field.typeOptions, nullable: false },
+      target: RequiredClass,
+    });
+  });
+  return RequiredClass as ClassType<Required<T>>;
+}
+
+export function PickType<T, K extends keyof T>(
+  BaseClass: ClassType<T>,
+  ...pickFields: K[]
+): ClassType<Pick<T, K>> {
+  class PickClass {}
+  InputType({ isAbstract: true })(PickClass);
+  ObjectType({ isAbstract: true })(PickClass);
+  InterfaceType({ isAbstract: true })(PickClass);
+
+  const fields = getMetadataStorage().fields.filter(
+    f =>
+      (f.target === BaseClass || BaseClass.prototype instanceof f.target) &&
+      pickFields.includes(f.name as K),
+  );
+
+  fields.forEach(field => {
+    getMetadataStorage().collectClassFieldMetadata({
+      ...field,
+      target: PickClass,
+    });
+  });
+  return PickClass as ClassType<Pick<T, K>>;
+}
+
+export function OmitType<T, K extends keyof T>(
+  BaseClass: ClassType<T>,
+  ...omitFields: K[]
+): ClassType<Omit<T, K>> {
+  class OmitClass {}
+  InputType({ isAbstract: true })(OmitClass);
+  ObjectType({ isAbstract: true })(OmitClass);
+  InterfaceType({ isAbstract: true })(OmitClass);
+
+  const fields = getMetadataStorage().fields.filter(
+    f =>
+      (f.target === BaseClass || BaseClass.prototype instanceof f.target) &&
+      !omitFields.includes(f.name as K),
+  );
+
+  fields.forEach(field => {
+    getMetadataStorage().collectClassFieldMetadata({
+      ...field,
+      target: OmitClass,
+    });
+  });
+  return OmitClass as ClassType<Omit<T, K>>;
+}

--- a/src/utils/types-transformation.ts
+++ b/src/utils/types-transformation.ts
@@ -1,9 +1,16 @@
 import { ObjectType, InputType, InterfaceType } from "../decorators";
+import {
+  inheritValidationMetadata,
+  inheritTransformationMetadata,
+  applyIsOptionalDecorator,
+} from "../helpers/inherit-metedata";
 import { ClassType } from "../interfaces";
 import { getMetadataStorage } from "../metadata";
 
 export function PartialType<T>(BaseClass: ClassType<T>): ClassType<Partial<T>> {
   const PartialClass = abstractClass();
+  inheritValidationMetadata(BaseClass, PartialClass);
+  inheritTransformationMetadata(BaseClass, PartialClass);
 
   const fields = getMetadataStorage().fields.filter(
     f => f.target === BaseClass || BaseClass.prototype instanceof f.target,
@@ -15,6 +22,7 @@ export function PartialType<T>(BaseClass: ClassType<T>): ClassType<Partial<T>> {
       typeOptions: { ...field.typeOptions, nullable: true },
       target: PartialClass,
     });
+    applyIsOptionalDecorator(PartialClass, field.name);
   });
 
   return PartialClass as ClassType<Partial<T>>;
@@ -22,6 +30,8 @@ export function PartialType<T>(BaseClass: ClassType<T>): ClassType<Partial<T>> {
 
 export function RequiredType<T>(BaseClass: ClassType<T>): ClassType<Required<T>> {
   const RequiredClass = abstractClass();
+  inheritValidationMetadata(BaseClass, RequiredClass);
+  inheritTransformationMetadata(BaseClass, RequiredClass);
 
   const fields = getMetadataStorage().fields.filter(
     f => f.target === BaseClass || BaseClass.prototype instanceof f.target,
@@ -42,6 +52,10 @@ export function PickType<T, K extends keyof T>(
   ...pickFields: K[]
 ): ClassType<Pick<T, K>> {
   const PickClass = abstractClass();
+
+  const isInheritedPredicate = (propertyKey: string) => pickFields.includes(propertyKey as K);
+  inheritValidationMetadata(BaseClass, PickClass, isInheritedPredicate);
+  inheritTransformationMetadata(BaseClass, PickClass, isInheritedPredicate);
 
   const fields = getMetadataStorage().fields.filter(
     f =>
@@ -64,6 +78,10 @@ export function OmitType<T, K extends keyof T>(
 ): ClassType<Omit<T, K>> {
   const OmitClass = abstractClass();
 
+  const isInheritedPredicate = (propertyKey: string) => !omitFields.includes(propertyKey as K);
+  inheritValidationMetadata(BaseClass, OmitClass, isInheritedPredicate);
+  inheritTransformationMetadata(BaseClass, OmitClass, isInheritedPredicate);
+
   const fields = getMetadataStorage().fields.filter(
     f =>
       (f.target === BaseClass || BaseClass.prototype instanceof f.target) &&
@@ -81,6 +99,10 @@ export function OmitType<T, K extends keyof T>(
 
 export function IntersectionType<A, B>(BaseClassA: ClassType<A>, BaseClassB: ClassType<B>) {
   const IntersectionClass = abstractClass();
+  inheritValidationMetadata(BaseClassA, IntersectionClass);
+  inheritTransformationMetadata(BaseClassA, IntersectionClass);
+  inheritValidationMetadata(BaseClassB, IntersectionClass);
+  inheritTransformationMetadata(BaseClassB, IntersectionClass);
 
   const fields = getMetadataStorage().fields.filter(
     f =>

--- a/src/utils/types-transformation.ts
+++ b/src/utils/types-transformation.ts
@@ -90,3 +90,27 @@ export function OmitType<T, K extends keyof T>(
   });
   return OmitClass as ClassType<Omit<T, K>>;
 }
+
+export function IntersectionType<A, B>(BaseClassA: ClassType<A>, BaseClassB: ClassType<B>) {
+  class IntersectionClass {}
+  InputType({ isAbstract: true })(IntersectionClass);
+  ObjectType({ isAbstract: true })(IntersectionClass);
+  InterfaceType({ isAbstract: true })(IntersectionClass);
+
+  const fields = getMetadataStorage().fields.filter(
+    f =>
+      f.target === BaseClassB ||
+      BaseClassB.prototype instanceof f.target ||
+      f.target === BaseClassA ||
+      BaseClassA.prototype instanceof f.target,
+  );
+
+  fields.forEach(field => {
+    getMetadataStorage().collectClassFieldMetadata({
+      ...field,
+      target: IntersectionClass,
+    });
+  });
+
+  return IntersectionClass as ClassType<A & B>;
+}

--- a/tests/functional/types-transformation.ts
+++ b/tests/functional/types-transformation.ts
@@ -1,0 +1,299 @@
+import "reflect-metadata";
+import { IntrospectionInputObjectType, IntrospectionObjectType, TypeKind } from "graphql";
+import {
+  Arg,
+  Args,
+  ArgsType,
+  ClassType,
+  Field,
+  getMetadataStorage,
+  InputType,
+  InterfaceType,
+  ObjectType,
+  OmitType,
+  PartialType,
+  PickType,
+  Query,
+  RequiredType,
+  Resolver,
+} from "../../src";
+import { getSchemaInfo } from "../helpers/getSchemaInfo";
+import { IntersectionType } from "../../src/utils/types-transformation";
+
+describe("Types transformation utils", () => {
+  beforeEach(() => {
+    getMetadataStorage().clear();
+  });
+
+  it("PartialType should set all fields to nullable", async () => {
+    @ObjectType()
+    class BaseObject {
+      @Field({ nullable: true })
+      baseFieldA: string;
+
+      @Field({ nullable: false })
+      baseFieldB: string;
+
+      @Field()
+      baseFieldC: string;
+    }
+
+    @ObjectType()
+    class SampleObject extends PartialType(BaseObject) {}
+
+    const sampleObjectType = await getSampleObjectType(SampleObject);
+
+    const baseFieldA = sampleObjectType.fields.find(field => field.name === "baseFieldA")!;
+    expect(baseFieldA.type.kind).toEqual(TypeKind.SCALAR);
+    const baseFieldB = sampleObjectType.fields.find(field => field.name === "baseFieldB")!;
+    expect(baseFieldB.type.kind).toEqual(TypeKind.SCALAR);
+    const baseFieldC = sampleObjectType.fields.find(field => field.name === "baseFieldC")!;
+    expect(baseFieldC.type.kind).toEqual(TypeKind.SCALAR);
+  });
+
+  it("RequiredType should set all fields to NON_NULL", async () => {
+    @ObjectType()
+    class BaseObject {
+      @Field({ nullable: true })
+      baseFieldA: string;
+
+      @Field({ nullable: false })
+      baseFieldB: string;
+
+      @Field()
+      baseFieldC: string;
+    }
+
+    @ObjectType()
+    class SampleObject extends RequiredType(BaseObject) {}
+
+    const sampleObjectType = await getSampleObjectType(SampleObject);
+
+    const baseFieldA = sampleObjectType.fields.find(field => field.name === "baseFieldA")!;
+    expect(baseFieldA.type.kind).toEqual(TypeKind.NON_NULL);
+    const baseFieldB = sampleObjectType.fields.find(field => field.name === "baseFieldB")!;
+    expect(baseFieldB.type.kind).toEqual(TypeKind.NON_NULL);
+    const baseFieldC = sampleObjectType.fields.find(field => field.name === "baseFieldC")!;
+    expect(baseFieldC.type.kind).toEqual(TypeKind.NON_NULL);
+  });
+
+  it("PickType should only define specified field", async () => {
+    @ObjectType()
+    class BaseObject {
+      @Field({ nullable: true })
+      baseFieldA: string;
+
+      @Field({ nullable: false })
+      baseFieldB: string;
+
+      @Field()
+      baseFieldC: string;
+    }
+
+    @ObjectType()
+    class SampleObject extends PickType(BaseObject, "baseFieldA") {}
+
+    const sampleObjectType = await getSampleObjectType(SampleObject);
+
+    const baseFieldA = sampleObjectType.fields.find(field => field.name === "baseFieldA")!;
+    expect(baseFieldA).toBeDefined();
+    const baseFieldB = sampleObjectType.fields.find(field => field.name === "baseFieldB")!;
+    expect(baseFieldB).toBeUndefined();
+    const baseFieldC = sampleObjectType.fields.find(field => field.name === "baseFieldC")!;
+    expect(baseFieldC).toBeUndefined();
+  });
+
+  it("OmitType should omit specified field", async () => {
+    @ObjectType()
+    class BaseObject {
+      @Field({ nullable: true })
+      baseFieldA: string;
+
+      @Field({ nullable: false })
+      baseFieldB: string;
+
+      @Field()
+      baseFieldC: string;
+    }
+
+    @ObjectType()
+    class SampleObject extends OmitType(BaseObject, "baseFieldA", "baseFieldB") {}
+
+    const sampleObjectType = await getSampleObjectType(SampleObject);
+
+    const baseFieldA = sampleObjectType.fields.find(field => field.name === "baseFieldA")!;
+    expect(baseFieldA).toBeUndefined();
+    const baseFieldB = sampleObjectType.fields.find(field => field.name === "baseFieldB")!;
+    expect(baseFieldB).toBeUndefined();
+    const baseFieldC = sampleObjectType.fields.find(field => field.name === "baseFieldC")!;
+    expect(baseFieldC).toBeDefined();
+  });
+
+  it("IntersectionType should combines two types into one new type", async () => {
+    @ObjectType()
+    class BaseObjectA {
+      @Field()
+      baseFieldA: string;
+    }
+
+    @ObjectType()
+    class BaseObjectB {
+      @Field()
+      baseFieldB: string;
+    }
+
+    @ObjectType()
+    class BaseObjectC {
+      @Field()
+      baseFieldC: string;
+    }
+
+    @ObjectType()
+    class SampleObject extends IntersectionType(
+      BaseObjectA,
+      IntersectionType(BaseObjectB, BaseObjectC),
+    ) {}
+
+    const sampleObjectType = await getSampleObjectType(SampleObject);
+
+    const baseFieldA = sampleObjectType.fields.find(field => field.name === "baseFieldA")!;
+    expect(baseFieldA).toBeDefined();
+    const baseFieldB = sampleObjectType.fields.find(field => field.name === "baseFieldB")!;
+    expect(baseFieldB).toBeDefined();
+    const baseFieldC = sampleObjectType.fields.find(field => field.name === "baseFieldC")!;
+    expect(baseFieldC).toBeDefined();
+  });
+
+  it("should composable", async () => {
+    @InputType()
+    class PartialObject {
+      @Field()
+      nullableStringField: string;
+    }
+
+    @ArgsType()
+    class RequiredObject {
+      @Field()
+      nonNullStringField: string;
+    }
+
+    @InterfaceType()
+    class PickedObject {
+      @Field()
+      pickedStringField: string;
+    }
+
+    @ObjectType()
+    class OmittedObject {
+      @Field()
+      OmittedStringField: string;
+    }
+
+    @ObjectType()
+    class SampleObject extends IntersectionType(
+      IntersectionType(PartialType(PartialObject), RequiredType(RequiredObject)),
+      IntersectionType(
+        PickType(PickedObject, "pickedStringField"),
+        OmitType(OmittedObject, "OmittedStringField"),
+      ),
+    ) {}
+
+    const sampleObjectType = await getSampleObjectType(SampleObject);
+
+    const nullableStringField = sampleObjectType.fields.find(
+      f => f.name === "nullableStringField",
+    )!;
+    expect(nullableStringField).toBeDefined();
+    expect(nullableStringField.type.kind).toEqual(TypeKind.SCALAR);
+
+    const nonNullStringField = sampleObjectType.fields.find(f => f.name === "nonNullStringField")!;
+    expect(nonNullStringField).toBeDefined();
+    expect(nonNullStringField.type.kind).toEqual(TypeKind.NON_NULL);
+
+    const OmittedStringField = sampleObjectType.fields.find(f => f.name === "OmittedStringField")!;
+    expect(OmittedStringField).toBeUndefined();
+
+    const pickedStringField = sampleObjectType.fields.find(f => f.name === "pickedStringField")!;
+    expect(pickedStringField).toBeDefined();
+  });
+
+  it("should work with InputType", async () => {
+    @ObjectType()
+    class BaseObject {
+      @Field({ nullable: false })
+      stringField: string;
+    }
+
+    @InputType()
+    class SampleArgs extends PartialType(BaseObject) {}
+
+    @Resolver()
+    class SampleResolver {
+      @Query()
+      sampleQuery(@Arg("sample") _args: SampleArgs): String {
+        return "";
+      }
+    }
+
+    const schemaInfo = await getSchemaInfo({
+      resolvers: [SampleResolver],
+    });
+    const schemaIntrospection = schemaInfo.schemaIntrospection;
+    const sampleInputType = schemaIntrospection.types.find(
+      type => type.name === "SampleArgs",
+    ) as IntrospectionInputObjectType;
+
+    const stringField = sampleInputType.inputFields.find(f => f.name === "stringField")!;
+    expect(stringField).toBeDefined();
+    expect(stringField.type.kind).toEqual(TypeKind.SCALAR);
+  });
+
+  it("should work with ArgsType", async () => {
+    @ObjectType()
+    class BaseObject {
+      @Field({ nullable: false })
+      stringField: string;
+    }
+
+    @ArgsType()
+    class SampleArgs extends PartialType(BaseObject) {}
+
+    @Resolver()
+    class SampleResolver {
+      @Query()
+      sampleQuery(@Args() _args: SampleArgs): String {
+        return "";
+      }
+    }
+
+    const schemaInfo = await getSchemaInfo({
+      resolvers: [SampleResolver],
+    });
+
+    const sampleQuery = schemaInfo.queryType.fields.find(f => f.name === "sampleQuery")!;
+    const stringField = sampleQuery.args[0];
+    console.log("sampleQuery: \n", sampleQuery);
+
+    expect(stringField).toBeDefined();
+    expect(stringField.type.kind).toEqual(TypeKind.SCALAR);
+  });
+});
+
+async function getSampleObjectType<SampleObject extends ClassType>(SampleObject: SampleObject) {
+  @Resolver()
+  class SampleResolver {
+    @Query(() => SampleObject)
+    sampleQuery(): SampleObject {
+      return {} as SampleObject;
+    }
+  }
+
+  const schemaInfo = await getSchemaInfo({
+    resolvers: [SampleResolver],
+  });
+  const schemaIntrospection = schemaInfo.schemaIntrospection;
+  const sampleObjectType = schemaIntrospection.types.find(
+    type => type.name === "SampleObject",
+  ) as IntrospectionObjectType;
+  return sampleObjectType;
+}


### PR DESCRIPTION
This PR implements  #453 
Types transformation utils is a feature that has been on the back burner for a long time.

This PR comes with five utils types as: 
- PartialType: set all fields to nullable
- RequiredType: set all fields to NON_NULL
- PickType: only define specified field to a new type
- OmitType: omit specified field to a new type
- IntersectionType:  combines two types into one new type

Use it like so:
``` typescript
@InputType()
class PartialObject {
  @Field()
  nullableStringField: string;
}

@ArgsType()
class RequiredObject {
  @Field()
  nonNullStringField: string;
}

@InterfaceType()
class PickedObject {
  @Field()
  pickedStringField: string;
}

@ObjectType()
class OmittedObject {
  @Field()
  OmittedStringField: string;
}

@ObjectType()
class SampleObject extends IntersectionType(
  IntersectionType(PartialType(PartialObject), RequiredType(RequiredObject)),
  IntersectionType(
    PickType(PickedObject, "pickedStringField"),
    OmitType(OmittedObject, "OmittedStringField"),
  ),
) {}

```

It work with `class-validator` and `class-transformer`
Actually, this code has been in our own repository for a year, it refers to the implementation of nestjs and https://github.com/MichalLytek/type-graphql/issues/453#issuecomment-567049672

In addition, I didn't find a way to implement `mapping util` that ensures type safety.

