### PR TITLE
Introducing TypeGraphQL Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![codecov](https://codecov.io/gh/MichalLytek/type-graphql/branch/master/graph/badge.svg)](https://codecov.io/gh/MichalLytek/type-graphql)
 [![npm](https://img.shields.io/npm/v/type-graphql?logo=npm&color=%23CC3534)](https://www.npmjs.com/package/type-graphql)
 [![open collective](https://opencollective.com/typegraphql/tiers/badge.svg)](https://opencollective.com/typegraphql)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20TypeGraphQL%20Guru-006BFF)](https://gurubase.io/g/typegraphql)
 
 Create [GraphQL](https://graphql.org) schema and resolvers with [TypeScript](https://www.typescriptlang.org), using classes and decorators!
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [TypeGraphQL Guru](https://gurubase.io/g/typegraphql) to Gurubase. TypeGraphQL Guru uses the data from this repo and data from the [docs](https://typegraphql.com) to answer questions by leveraging the LLM.

In this PR, I showcased the "TypeGraphQL Guru", which highlights that TypeGraphQL now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable TypeGraphQL Guru in Gurubase, just let me know that's totally fine.
