### PR TITLE
AdonisJS integration

### DIFF
--- a/docs/adonisjs.md
+++ b/docs/adonisjs.md
@@ -1,0 +1,45 @@
+---
+title: AdonisJS Integration
+sidebar_label: AdonisJS
+---
+
+[`@foadonis/graphql`](https://friendsofadonis.com/docs/graphql) is a fully featured package to build GraphQL APIs with [AdonisJS](https://adonisjs.com/) powered by TypeGraphQL and [Apollo Server](https://www.apollographql.com/docs/apollo-server).
+
+It supports subscriptions out of the box and brings scalars for [Luxon](https://moment.github.io/luxon/#/) and [VineJS](https://vinejs.dev/). It also provide some helpers for authorization to create a seemless experience for building GraphQL APIs.
+
+## Overview
+
+To get started on an existing AdonisJS project a single command is required, it will install all the required dependencies:
+
+```sh
+node ace add @foadonis/graphql
+```
+
+Once done, you can start your AdonisJS application and access [http://localhost:3000/graphql](http://localhost:3000/graphql) that will great you with the [Apollo Sandbox](https://www.apollographql.com/docs/apollo-sandbox).
+
+You can create your first resolver like so:
+
+```ts
+import Recipe from "#models/recipe";
+import { Query, Resolver } from "@foadonis/graphql";
+
+@Resolver()
+export default class RecipeResolver {
+  @Query(() => [Recipe])
+  recipes() {
+    return Recipe.query();
+  }
+}
+```
+
+Register your freshly created resolver in `start/graphql.ts`:
+
+```ts
+import graphql from "@foadonis/graphql/services/main";
+
+graphql.resolvers([() => import("#graphql/resolvers/recipe_resolver")]);
+```
+
+## Documentation
+
+You can find more information on the [Package Documentation Website](https://friendsofadonis.com/docs/graphql).

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -5,6 +5,10 @@
     "previous": "Previous",
     "tagline": "Modern framework for GraphQL API in Node.js",
     "docs": {
+      "adonisjs": {
+        "title": "AdonisJS Integration",
+        "sidebar_label": "AdonisJS"
+      },
       "authorization": {
         "title": "Authorization"
       },
@@ -811,6 +815,10 @@
       "version-2.0.0-rc.1/version-2.0.0-rc.1-validation": {
         "title": "Argument and Input validation",
         "sidebar_label": "Validation"
+      },
+      "version-2.0.0-rc.2/version-2.0.0-rc.2-adonisjs": {
+        "title": "AdonisJS Integration",
+        "sidebar_label": "AdonisJS"
       },
       "version-2.0.0-rc.2/version-2.0.0-rc.2-authorization": {
         "title": "Authorization"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -29,7 +29,7 @@
       "custom-decorators",
       "complexity"
     ],
-    "Integrations": ["prisma", "nestjs"],
+    "Integrations": ["prisma", "nestjs", "adonisjs"],
     "Others": ["emit-schema", "performance"],
     "Recipes": ["browser-usage", "aws-lambda", "azure-functions"]
   },

--- a/website/versioned_docs/version-2.0.0-rc.2/adonisjs.md
+++ b/website/versioned_docs/version-2.0.0-rc.2/adonisjs.md
@@ -1,0 +1,47 @@
+---
+title: AdonisJS Integration
+sidebar_label: AdonisJS
+id: version-2.0.0-rc.2-adonisjs
+original_id: adonisjs
+---
+
+[`@foadonis/graphql`](https://friendsofadonis.com/docs/graphql) is a fully featured package to build GraphQL APIs with [AdonisJS](https://adonisjs.com/) powered by TypeGraphQL and [Apollo Server](https://www.apollographql.com/docs/apollo-server).
+
+It supports subscriptions out of the box and brings scalars for [Luxon](https://moment.github.io/luxon/#/) and [VineJS](https://vinejs.dev/). It also provide some helpers for authorization to create a seamless experience for building GraphQL APIs.
+
+## Overview
+
+To get started on an existing AdonisJS project a single command is required, it will install all the required dependencies and generate configuration files:
+
+```sh
+node ace add @foadonis/graphql
+```
+
+Once done, you can start your AdonisJS application and access [http://localhost:3000/graphql](http://localhost:3000/graphql) that will great you with the [Apollo Sandbox](https://www.apollographql.com/docs/apollo-sandbox).
+
+You can create your first resolver like so:
+
+```ts
+import Recipe from "#models/recipe";
+import { Query, Resolver } from "@foadonis/graphql";
+
+@Resolver()
+export default class RecipeResolver {
+  @Query(() => [Recipe])
+  recipes() {
+    return Recipe.query();
+  }
+}
+```
+
+Register your freshly created resolver in `start/graphql.ts`:
+
+```ts
+import graphql from "@foadonis/graphql/services/main";
+
+graphql.resolvers([() => import("#graphql/resolvers/recipe_resolver")]);
+```
+
+## Documentation
+
+You can find more information on the [package documentation website](https://friendsofadonis.com/docs/graphql).

--- a/website/versioned_sidebars/version-2.0.0-rc.2-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.0-rc.2-sidebars.json
@@ -35,7 +35,8 @@
     ],
     "Integrations": [
       "version-2.0.0-rc.2-prisma",
-      "version-2.0.0-rc.2-nestjs"
+      "version-2.0.0-rc.2-nestjs",
+      "version-2.0.0-rc.2-adonisjs"
     ],
     "Others": [
       "version-2.0.0-rc.2-emit-schema",


### PR DESCRIPTION
Hi! We have recently released the first version of Adonis GraphQL, it is built on top of TypeGraphQL and I have to say that building this "adapter" with it has been a great journey!

This pull-request simply adds a short documentation page about Adonis GraphQL and how to get started.

Happy to discuss about changes, it might requires a disclaimer `Not maintained by TypeGraphQL`.

- Source code: https://github.com/FriendsOfAdonis/FriendsOfAdonis/tree/main/packages/graphql
- Documentation: https://friendsofadonis.com/docs/graphql