### PR TITLE
fix(schema): match field resolvers by schemaName instead of methodName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog and release notes
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixes
+
+- support resolver inheritance with dynamic field resolvers name by matching field resolvers by schemaName instead of methodName (#1806)
 
 <!-- Here goes all the unreleased changes descriptions -->
 

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -338,7 +338,8 @@ export abstract class SchemaGenerator {
                     it => it.kind === "internal" || resolvers.includes(it.target),
                   );
                   const fieldResolverMetadata = filteredFieldResolversMetadata.find(
-                    it => it.getObjectType!() === field.target && it.methodName === field.name,
+                    it =>
+                      it.getObjectType!() === field.target && it.schemaName === field.schemaName,
                   );
                   const type = this.getGraphQLOutputType(
                     field.target,
@@ -456,7 +457,7 @@ export abstract class SchemaGenerator {
                   const fieldResolverMetadata = this.metadataStorage.fieldResolvers.find(
                     resolver =>
                       resolver.getObjectType!() === field.target &&
-                      resolver.methodName === field.name,
+                      resolver.schemaName === field.schemaName,
                   );
                   const type = this.getGraphQLOutputType(
                     field.target,

--- a/tests/functional/resolvers.ts
+++ b/tests/functional/resolvers.ts
@@ -2618,6 +2618,62 @@ describe("Resolvers", () => {
       expect(dynamicField1).toBeDefined();
       expect(dynamicField2).toBeDefined();
     });
+
+    it("should resolve independent factory-created field resolvers with different schema names correctly", async () => {
+      getMetadataStorage().clear();
+
+      @ObjectType()
+      class FactoryUser {
+        @Field()
+        name!: string;
+      }
+
+      function createFieldResolver(fieldName: string, returnValue: string) {
+        @Resolver(() => FactoryUser)
+        class DynamicFieldResolver {
+          @FieldResolver(() => [String], { name: fieldName })
+          getItems(): string[] {
+            return [returnValue];
+          }
+        }
+        return DynamicFieldResolver;
+      }
+
+      const FollowersResolver = createFieldResolver("followers", "follower1");
+      const FollowingResolver = createFieldResolver("following", "following1");
+
+      @Resolver()
+      class FactoryUserResolver {
+        @Query(() => FactoryUser)
+        factoryUser(): FactoryUser {
+          return { name: "TestUser" } as FactoryUser;
+        }
+      }
+
+      const schemaInfo = await getSchemaInfo({
+        resolvers: [FactoryUserResolver, FollowersResolver, FollowingResolver],
+      });
+      const { schema: factorySchema, schemaIntrospection: factorySchemaIntrospection } = schemaInfo;
+
+      // Introspection check
+      const factoryUserType = factorySchemaIntrospection.types.find(
+        type => type.name === "FactoryUser",
+      ) as IntrospectionObjectType;
+      expect(factoryUserType.fields.find(f => f.name === "followers")).toBeDefined();
+      expect(factoryUserType.fields.find(f => f.name === "following")).toBeDefined();
+
+      // Runtime execution check
+      const query = `{ factoryUser { name followers following } }`;
+      const result = await graphql({ schema: factorySchema, source: query });
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toEqual({
+        factoryUser: {
+          name: "TestUser",
+          followers: ["follower1"],
+          following: ["following1"],
+        },
+      });
+    });
   });
 
   describe("Shared generic resolver", () => {


### PR DESCRIPTION
## Summary

Fixes #961.

- Field resolvers with a custom `name` option (via `@FieldResolver({ name })`) were matched to fields using `methodName` instead of `schemaName` in the schema generator
- This meant factory-created resolvers sharing the same method name but with different `name` options would either all resolve to the first match or not resolve at all
- Changed both ObjectType and InterfaceType field resolver lookups to match by `schemaName` — consistent with how `buildFieldResolverMetadata` already works in metadata-storage.ts

## Test plan

- [x] Added test: independent factory-created field resolvers with different `name` options, verifying both schema introspection and runtime execution
- [x] All 112 existing resolver tests pass
- [x] All 4 metadata-storage tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/michallytek/type-graphql/pull/1806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
