### PR TITLE
feat(schema): add directives support to registerEnumType

### DIFF
--- a/src/decorators/enums.ts
+++ b/src/decorators/enums.ts
@@ -10,5 +10,6 @@ export function registerEnumType<TEnum extends object>(
     name: enumConfig.name,
     description: enumConfig.description,
     valuesConfig: enumConfig.valuesConfig || {},
+    directives: enumConfig.directives?.map(nameOrDefinition => ({ nameOrDefinition, args: {} })),
   });
 }

--- a/src/decorators/types.ts
+++ b/src/decorators/types.ts
@@ -77,6 +77,7 @@ export interface EnumConfig<TEnum extends object> {
   name: string;
   description?: string;
   valuesConfig?: EnumValuesConfig<TEnum>;
+  directives?: string[];
 }
 export type EnumValuesConfig<TEnum extends object> = Partial<
   Record<keyof TEnum, DescriptionOptions & DeprecationOptions>

--- a/src/metadata/definitions/enum-metadata.ts
+++ b/src/metadata/definitions/enum-metadata.ts
@@ -1,8 +1,10 @@
 import { type EnumValuesConfig } from "@/decorators/types";
+import { type DirectiveMetadata } from "./directive-metadata";
 
 export interface EnumMetadata {
   enumObj: object;
   name: string;
   description: string | undefined;
   valuesConfig: EnumValuesConfig<any>;
+  directives?: DirectiveMetadata[];
 }

--- a/src/schema/definition-node.ts
+++ b/src/schema/definition-node.ts
@@ -2,6 +2,7 @@ import {
   type ConstArgumentNode,
   type ConstDirectiveNode,
   type DocumentNode,
+  type EnumTypeDefinitionNode,
   type FieldDefinitionNode,
   type GraphQLInputType,
   type GraphQLOutputType,
@@ -176,6 +177,24 @@ export function getInterfaceTypeDefinitionNode(
     name: {
       kind: Kind.NAME,
       // FIXME: use proper AST representation
+      value: name,
+    },
+    directives: directiveMetadata.map(getDirectiveNode),
+  };
+}
+
+export function getEnumTypeDefinitionNode(
+  name: string,
+  directiveMetadata?: DirectiveMetadata[],
+): EnumTypeDefinitionNode | undefined {
+  if (!directiveMetadata || !directiveMetadata.length) {
+    return undefined;
+  }
+
+  return {
+    kind: Kind.ENUM_TYPE_DEFINITION,
+    name: {
+      kind: Kind.NAME,
       value: name,
     },
     directives: directiveMetadata.map(getDirectiveNode),

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -56,6 +56,7 @@ import {
 import { ensureInstalledCorrectGraphQLPackage } from "@/utils/graphql-version";
 import { BuildContext, type BuildContextOptions } from "./build-context";
 import {
+  getEnumTypeDefinitionNode,
   getFieldDefinitionNode,
   getInputObjectTypeDefinitionNode,
   getInputValueDefinitionNode,
@@ -255,6 +256,7 @@ export abstract class SchemaGenerator {
           type: new GraphQLEnumType({
             name: enumMetadata.name,
             description: enumMetadata.description,
+            astNode: getEnumTypeDefinitionNode(enumMetadata.name, enumMetadata.directives),
             values: Object.keys(enumMap).reduce<GraphQLEnumValueConfigMap>(
               (enumConfig, enumKey) => {
                 const valueConfig = enumMetadata.valuesConfig[enumKey] || {};

--- a/tests/functional/enums.ts
+++ b/tests/functional/enums.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import {
+  type GraphQLEnumType,
   type GraphQLSchema,
   type IntrospectionEnumType,
   type IntrospectionInputObjectType,
@@ -10,6 +11,7 @@ import {
 } from "graphql";
 import { Arg, Field, InputType, Query, registerEnumType } from "type-graphql";
 import { getMetadataStorage } from "@/metadata/getMetadataStorage";
+import { assertValidDirective } from "../helpers/directives/assertValidDirective";
 import {
   getInnerInputFieldType,
   getInnerTypeOfNonNullableType,
@@ -51,6 +53,15 @@ describe("Enums", () => {
       },
     });
 
+    enum DirectiveEnum {
+      Active = "ACTIVE",
+      Inactive = "INACTIVE",
+    }
+    registerEnumType(DirectiveEnum, {
+      name: "DirectiveEnum",
+      directives: ["@test"],
+    });
+
     @InputType()
     class NumberEnumInput {
       @Field(() => NumberEnum)
@@ -87,6 +98,11 @@ describe("Enums", () => {
       @Query()
       isStringEnumEqualOne(@Arg("enum", () => StringEnum) stringEnum: StringEnum): boolean {
         return stringEnum === StringEnum.One;
+      }
+
+      @Query(() => DirectiveEnum)
+      getDirectiveEnumValue(): DirectiveEnum {
+        return DirectiveEnum.Active;
       }
     }
 
@@ -200,6 +216,84 @@ describe("Enums", () => {
       expect(advancedEnumType.enumValues[1].deprecationReason).toEqual(
         "Two field deprecation reason",
       );
+    });
+
+    it("should properly emit directive in AST when directives are provided", async () => {
+      const enumType = schema.getType("DirectiveEnum") as GraphQLEnumType;
+
+      expect(enumType).toBeDefined();
+      expect(enumType.astNode).toBeDefined();
+      assertValidDirective(enumType.astNode, "test");
+    });
+
+    it("should leave astNode undefined when no directives are provided", async () => {
+      const enumType = schema.getType("NumberEnum") as GraphQLEnumType;
+
+      expect(enumType).toBeDefined();
+      expect(enumType.astNode).toBeUndefined();
+    });
+
+    it("should properly emit directive with args in AST", async () => {
+      getMetadataStorage().clear();
+
+      enum ArgsDirectiveEnum {
+        On = "ON",
+        Off = "OFF",
+      }
+      registerEnumType(ArgsDirectiveEnum, {
+        name: "ArgsDirectiveEnum",
+        directives: ['@test(argNonNullDefault: "custom", argNull: "value")'],
+      });
+
+      class ArgsDirectiveEnumResolver {
+        @Query(() => ArgsDirectiveEnum)
+        getArgsDirectiveEnumValue(): ArgsDirectiveEnum {
+          return ArgsDirectiveEnum.On;
+        }
+      }
+
+      const { schema: argsSchema } = await getSchemaInfo({
+        resolvers: [ArgsDirectiveEnumResolver],
+      });
+
+      const enumType = argsSchema.getType("ArgsDirectiveEnum") as GraphQLEnumType;
+      expect(enumType.astNode).toBeDefined();
+      assertValidDirective(enumType.astNode, "test", {
+        argNonNullDefault: `"custom"`,
+        argNull: `"value"`,
+      });
+    });
+
+    it("should properly emit multiple directives in AST", async () => {
+      getMetadataStorage().clear();
+
+      enum MultiDirectiveEnum {
+        Yes = "YES",
+        No = "NO",
+      }
+      registerEnumType(MultiDirectiveEnum, {
+        name: "MultiDirectiveEnum",
+        directives: ["@test", '@deprecated(reason: "use something else")'],
+      });
+
+      class MultiDirectiveEnumResolver {
+        @Query(() => MultiDirectiveEnum)
+        getMultiDirectiveEnumValue(): MultiDirectiveEnum {
+          return MultiDirectiveEnum.Yes;
+        }
+      }
+
+      const { schema: multiSchema } = await getSchemaInfo({
+        resolvers: [MultiDirectiveEnumResolver],
+      });
+
+      const enumType = multiSchema.getType("MultiDirectiveEnum") as GraphQLEnumType;
+      expect(enumType.astNode).toBeDefined();
+      expect(enumType.astNode!.directives).toHaveLength(2);
+      assertValidDirective(enumType.astNode, "test");
+      assertValidDirective(enumType.astNode, "deprecated", {
+        reason: `"use something else"`,
+      });
     });
   });
 

--- a/tests/helpers/directives/assertValidDirective.ts
+++ b/tests/helpers/directives/assertValidDirective.ts
@@ -1,4 +1,5 @@
 import {
+  type EnumTypeDefinitionNode,
   type FieldDefinitionNode,
   type InputObjectTypeDefinitionNode,
   type InputValueDefinitionNode,
@@ -10,6 +11,7 @@ import { type Maybe } from "@/typings";
 
 export function assertValidDirective(
   astNode: Maybe<
+    | EnumTypeDefinitionNode
     | FieldDefinitionNode
     | ObjectTypeDefinitionNode
     | InputObjectTypeDefinitionNode


### PR DESCRIPTION
- Add optional `directives: string[]` parameter to `registerEnumType`, enabling directive support on enum types (e.g. `directives: ["@cacheControl(maxAge: 30)"])`
- Follow the same directive handling pattern used by `ObjectType`, `InterfaceType`, and `InputType` — directive strings are converted to `DirectiveMetadata`, processed through `getEnumTypeDefinitionNode`, and emitted as `astNode` on the `GraphQLEnumType`
- Add tests covering simple directives, directives with arguments, and multiple directives on a single enum

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/michallytek/type-graphql/pull/1807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
