### PR TITLE
docs: complete v2.0 migration guide and add announcement blog post

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -98,3 +98,364 @@ Also, apart from the `Publisher` type mentioned above, the `PubSubEngine` type h
 As TypeGraphQL uses `@graphql-yoga/subscriptions` under the hood, it also aims to use its features. And one of the extension to the old `PubSub` system used in `v1.x` is ability to not only use dynamic topics but a topic with a dynamic id.
 
 You can read more about this new feature in [subscription docs](./subscriptions.md#topic-with-dynamic-id).
+
+## Resolver loading
+
+Support for loading resolvers by glob path strings has been removed in `v2.0`.
+
+Previously, you could pass glob patterns to the `resolvers` option:
+
+```ts
+const schema = await buildSchema({
+  resolvers: [__dirname + "/resolvers/**/*.ts"],
+});
+```
+
+This is no longer supported. You must now pass an array of resolver class references:
+
+```ts
+import { RecipeResolver } from "./resolvers/recipe-resolver";
+import { UserResolver } from "./resolvers/user-resolver";
+
+const schema = await buildSchema({
+  resolvers: [RecipeResolver, UserResolver],
+});
+```
+
+The glob path approach was removed because it relied on dynamic `require` calls that don't work well with modern compilers, bundlers, and ESM. It also caused confusion with needing different file extensions for development vs production, and was the root cause of the old `isAbstract` decorator option (which has also been removed).
+
+## Authorization system
+
+### `AuthChecker` type change
+
+The `AuthChecker` type is now a union of a function or a class, in order to support class-based auth checkers with dependency injection.
+
+If you reference `AuthChecker` as a type annotation where only the function form is expected, update your code to use `AuthCheckerFn` instead:
+
+```ts
+// Before (v1.x)
+import { AuthChecker } from "type-graphql";
+
+const authChecker: AuthChecker<MyContext> = ({ context }, roles) => {
+  return context.user !== undefined;
+};
+
+// After (v2.0) - if you need the function-only type
+import { AuthCheckerFn } from "type-graphql";
+
+const authChecker: AuthCheckerFn<MyContext> = ({ context }, roles) => {
+  return context.user !== undefined;
+};
+```
+
+Note that passing a function to the `authChecker` option of `buildSchema` still works the same way — this change only affects code that uses the `AuthChecker` type directly as a type annotation.
+
+### New class-based auth checker
+
+`v2.0` introduces support for class-based auth checkers via the `AuthCheckerInterface`. This enables dependency injection for auth logic:
+
+```ts
+import { type AuthCheckerInterface, type ResolverData } from "type-graphql";
+
+class CustomAuthChecker implements AuthCheckerInterface<MyContext> {
+  check({ context }: ResolverData<MyContext>, roles: string[]) {
+    return context.user !== undefined;
+  }
+}
+
+const schema = await buildSchema({
+  resolvers,
+  authChecker: CustomAuthChecker,
+});
+```
+
+You can also now apply `@Authorized()` at the resolver class level, which will protect all queries, mutations, and subscriptions defined in that resolver. Read more in the [authorization docs](./authorization.md).
+
+### Removed error classes
+
+The `UnauthorizedError` and `ForbiddenError` classes have been removed and replaced with new error classes that extend `GraphQLError`:
+
+- `UnauthorizedError` → `AuthenticationError` (with `extensions.code: "UNAUTHENTICATED"`)
+- `ForbiddenError` → `AuthorizationError` (with `extensions.code: "UNAUTHORIZED"`)
+
+If you imported these errors in your code, update the imports:
+
+```ts
+// Before (v1.x)
+import { UnauthorizedError, ForbiddenError } from "type-graphql";
+
+// After (v2.0)
+import { AuthenticationError, AuthorizationError } from "type-graphql";
+```
+
+## Validation system
+
+### Validation disabled by default
+
+In `v1.x`, integration with `class-validator` was enabled by default. In `v2.0`, the `validate` option of `buildSchema` is set to `false` by default.
+
+If your project relies on automatic argument validation, you need to explicitly enable it:
+
+```ts
+const schema = await buildSchema({
+  resolvers,
+  validate: true,
+});
+```
+
+### `class-validator` is now optional
+
+Since validation is disabled by default, `class-validator` is now an optional peer dependency. You only need to install it if you set `validate: true`:
+
+```sh
+npm install class-validator
+```
+
+### Custom validation function
+
+The `validate` option of `buildSchema` no longer accepts a custom validation function. Use the new `validateFn` option instead:
+
+```ts
+// Before (v1.x)
+const schema = await buildSchema({
+  resolvers,
+  validate: myCustomValidationFn,
+});
+
+// After (v2.0)
+const schema = await buildSchema({
+  resolvers,
+  validateFn: myCustomValidationFn,
+});
+```
+
+### `ValidatorFn` signature change
+
+The `ValidatorFn` type signature has changed. Previously it was generic over the args type and received only the args value. Now it is generic over the context type and receives three arguments — the argument value, the argument type, and the full resolver data:
+
+```ts
+// Before (v1.x)
+type ValidatorFn<TArgs = object> = (args: TArgs) => void | Promise<void>;
+
+// After (v2.0)
+type ValidatorFn<TContext extends object = object> = (
+  argValue: any | undefined,
+  argType: TypeValue,
+  resolverData: ResolverData<TContext>,
+) => void | Promise<void>;
+```
+
+This gives custom validation functions access to the full resolver context (`root`, `args`, `context`, `info`).
+
+### Per-argument validation
+
+You can now also pass a custom `validateFn` directly on `@Arg()` and `@Args()` decorators, for fine-grained per-argument validation:
+
+```ts
+@Query(() => [Recipe])
+async recipes(
+  @Args({ validateFn: myCustomValidation }) args: GetRecipesArgs,
+) {
+  // ...
+}
+```
+
+### `ArgumentValidationError` changes
+
+`ArgumentValidationError` now extends `GraphQLError` with structured error details in the `extensions` property:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Argument Validation Error",
+      "extensions": {
+        "code": "BAD_USER_INPUT",
+        "validationErrors": [...]
+      }
+    }
+  ]
+}
+```
+
+If you were previously accessing `error.validationErrors` directly, update your code to access `error.extensions.validationErrors` instead.
+
+## Error classes
+
+All TypeGraphQL error classes now extend `GraphQLError` from the `graphql` package, with error codes in the `extensions` property.
+
+Summary of error class changes:
+
+| v1.x                      | v2.0                      | `extensions.code`   |
+| ------------------------- | ------------------------- | ------------------- |
+| `UnauthorizedError`       | `AuthenticationError`     | `"UNAUTHENTICATED"` |
+| `ForbiddenError`          | `AuthorizationError`      | `"UNAUTHORIZED"`    |
+| `ArgumentValidationError` | `ArgumentValidationError` | `"BAD_USER_INPUT"`  |
+
+All error details that were previously direct properties on the error objects are now accessible through the standard `extensions` property. For production usage, you can use your server's error formatting mechanism (e.g. Apollo's `formatError` or Yoga's `maskError`) to filter sensitive information.
+
+## Scalars and date handling
+
+### `dateScalarMode` removed
+
+The `dateScalarMode` option has been removed from `buildSchema`. In `v1.x`, you could toggle between ISO string and Unix timestamp formats:
+
+```ts
+// Before (v1.x) - no longer works
+const schema = await buildSchema({
+  resolvers,
+  dateScalarMode: "timestamp",
+});
+```
+
+Instead, use the `scalarsMap` option to explicitly map `Date` to the scalar you want:
+
+```ts
+// After (v2.0) - use scalarsMap
+import { GraphQLTimestamp } from "graphql-scalars";
+
+const schema = await buildSchema({
+  resolvers,
+  scalarsMap: [{ type: Date, scalar: GraphQLTimestamp }],
+});
+```
+
+### `graphql-scalars` is a peer dependency
+
+Date scalars are now provided by the `graphql-scalars` package rather than being built-in. This package must be installed as a peer dependency:
+
+```sh
+npm install graphql-scalars
+```
+
+The exported `GraphQLISODateTime` from `type-graphql` is now a re-export of `GraphQLDateTimeISO` from `graphql-scalars`. See the [DateTimeISO section](#new-datetimeiso-scalar-name-in-schema) above for details on handling the scalar name change.
+
+## Custom decorators API
+
+### Renamed functions
+
+Two decorator factory functions have been renamed for clarity:
+
+- `createMethodDecorator` → `createMethodMiddlewareDecorator`
+- `createParamDecorator` → `createParameterDecorator`
+
+Update your imports accordingly:
+
+```ts
+// Before (v1.x)
+import { createMethodDecorator, createParamDecorator } from "type-graphql";
+
+// After (v2.0)
+import { createMethodMiddlewareDecorator, createParameterDecorator } from "type-graphql";
+```
+
+### New class-level middleware decorator
+
+A new `createResolverClassMiddlewareDecorator` function has been added. It allows creating custom decorators that apply middleware to all handlers in a resolver class:
+
+```ts
+import { createResolverClassMiddlewareDecorator } from "type-graphql";
+
+const LogAccess = createResolverClassMiddlewareDecorator(async ({ info }, next) => {
+  console.log(`Accessed: ${info.parentType.name}.${info.fieldName}`);
+  return next();
+});
+
+@LogAccess
+@Resolver()
+class RecipeResolver {
+  // all queries and mutations in this resolver will be logged
+}
+```
+
+### Custom parameter decorators with schema arguments
+
+`createParameterDecorator` now accepts an optional second argument `CustomParameterOptions` with an `arg` property. This lets you create custom decorators that also register a GraphQL argument in the schema:
+
+```ts
+import { createParameterDecorator } from "type-graphql";
+
+function CurrentPage() {
+  return createParameterDecorator(({ args }) => args.page, {
+    arg: {
+      name: "page",
+      typeFunc: () => Int,
+      options: { defaultValue: 1 },
+    },
+  });
+}
+```
+
+## Removed deprecated options
+
+### `isAbstract` decorator option
+
+The `isAbstract` option on `@ObjectType`, `@InputType`, and `@InterfaceType` decorators has been removed. It was previously used to prevent types from being emitted in the schema when using glob path resolution. Since glob paths are no longer supported and only explicitly imported resolver classes are used, this option is no longer needed.
+
+If your code uses `isAbstract`, simply remove it:
+
+```ts
+// Before (v1.x)
+@ObjectType({ isAbstract: true })
+class BaseEntity { ... }
+
+// After (v2.0) - just remove isAbstract
+@ObjectType()
+class BaseEntity { ... }
+```
+
+### `commentDescriptions` option
+
+The `commentDescriptions` option has been removed from `PrintSchemaOptions` (used in `emitSchemaFile`). GraphQL v16 no longer supports `#` comments for descriptions in SDL — only the standard `"""` block string descriptions are used.
+
+## Nullability and default values
+
+### Fixed nullability with `defaultValue`
+
+In `v1.x`, fields with a `defaultValue` were always emitted as non-nullable in the schema, regardless of the `nullable` option. This has been fixed in `v2.0` — the `nullable` option is now respected even when `defaultValue` is provided.
+
+The `ConflictingDefaultWithNullableError` error class has been removed since this combination is now valid.
+
+### Input field `name` option disabled
+
+The `@Field({ name: "..." })` option for renaming fields in the schema has been disabled for input types. This feature had broken behavior for inputs where the renamed field could not be properly mapped back from the GraphQL input to the class property.
+
+## Schema validation in `buildSchemaSync`
+
+In `v1.x`, `buildSchemaSync` did not validate the generated schema, which meant invalid schemas could be created without any errors. In `v2.0`, `buildSchemaSync` now runs the same validation as `buildSchema` (via GraphQL introspection query).
+
+If your schema has issues, `buildSchemaSync` will now throw a `GeneratingSchemaError` at build time instead of silently producing an invalid schema that would fail at query time.
+
+## TypeScript and build target
+
+### Build target
+
+The package is now compiled with a target of `ES2021` (previously `ES2018`).
+
+### Node.js version
+
+Node.js >= 20.11.1 is now required. Support for Node.js 16.x and 18.x has been dropped.
+
+### `ClassType` constraint
+
+The generic constraint on `ClassType` has been tightened from `ClassType<T = any>` to `ClassType<T extends object = object>`. If you use `ClassType` in your code with a non-object type parameter, you will need to adjust your types.
+
+## ESM support
+
+TypeGraphQL `v2.0` ships both CommonJS and ESM bundles. If your project uses ESM (`"type": "module"` in `package.json`), it should just work.
+
+A new `type-graphql/shim` entry point is also available for browser or frontend usage scenarios where the `reflect-metadata` polyfill is not needed. Read more in the [ESM docs](./esm.md) and [browser usage recipe](./browser-usage.md).
+
+## Peer dependencies
+
+Make sure to update your peer dependencies to the required minimum versions:
+
+```sh
+npm install graphql@^16.12.0 graphql-scalars@^1.25.0 type-graphql
+```
+
+| Dependency        | Required version | Notes                                      |
+| ----------------- | ---------------- | ------------------------------------------ |
+| `graphql`         | `^16.12.0`       | Updated from `^15.x`                       |
+| `graphql-scalars` | `^1.25.0`        | New required peer dependency               |
+| `class-validator` | `>=0.14.3`       | Optional — only needed if `validate: true` |

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -454,6 +454,8 @@ Make sure to update your peer dependencies to the required minimum versions:
 npm install graphql@^16.12.0 graphql-scalars@^1.25.0 type-graphql
 ```
 
+Note that `graphql` has been updated from `^15.x` to `^16.x`. GraphQL.js v16 has its own breaking changes — most notably, it drops support for `#` comment descriptions in SDL (which is why `commentDescriptions` was removed), and some error handling internals changed. If you're coming from `graphql@15`, review the [graphql-js v16 release notes](https://github.com/graphql/graphql-js/releases/tag/v16.0.0) as well.
+
 | Dependency        | Required version | Notes                                      |
 | ----------------- | ---------------- | ------------------------------------------ |
 | `graphql`         | `^16.12.0`       | Updated from `^15.x`                       |

--- a/website/blog/2026-03-26-typegraphql-2.md
+++ b/website/blog/2026-03-26-typegraphql-2.md
@@ -1,0 +1,170 @@
+---
+title: Announcing TypeGraphQL 2.0 🚀
+author: Michał Lytek
+authorURL: https://github.com/MichalLytek
+authorImageURL: /img/author.jpg
+---
+
+It's finally happening! After a long journey through multiple betas and release candidates, TypeGraphQL `v2.0` is now stable 🎉
+
+A lot has changed in the Node.js world since the [1.0 release](./2020-08-19-devto-article.md) — ESM became a real thing, `graphql-subscriptions` got abandoned, and the ecosystem moved forward. This release catches up with all of that while keeping the same decorator-based approach we all know and love.
+
+Well, then, without further ado... let's take a look what TypeGraphQL 2.0 brings us!
+
+- [Modern subscriptions engine](#modern-subscriptions-engine)
+- [Class-based auth checker](#class-based-auth-checker)
+- [Validation rework](#validation-rework)
+- [Custom decorators](#custom-decorators)
+- [ESM support](#esm-support)
+- [Scalars from the ecosystem](#scalars-from-the-ecosystem)
+- [GraphQL-native error handling](#graphql-native-error-handling)
+- [Performance and build improvements](#performance-and-build-improvements)
+- [Migration guide](#migration-guide)
+- [What's next?](#whats-next)
+
+<!--truncate-->
+
+## Modern subscriptions engine
+
+One of the biggest changes in 2.0 is the subscriptions system. The old [`graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions) package had become unmaintained, so we migrated to [`@graphql-yoga/subscriptions`](https://the-guild.dev/graphql/yoga-server/docs/features/subscriptions) — a modern, actively maintained alternative built on top of the latest ECMAScript features.
+
+The new PubSub system is type-safe out of the box. You define your topic types once, and TypeScript makes sure you publish the right payload to the right topic:
+
+```ts
+import { createPubSub } from "@graphql-yoga/subscriptions";
+
+export const pubSub = createPubSub<{
+  NOTIFICATIONS: [NotificationPayload];
+  NEW_COMMENT: [number, CommentPayload]; // topic with dynamic ID
+}>();
+```
+
+The `pubSub` instance is now passed directly to `buildSchema` instead of being auto-created internally, and the old `@PubSub` decorator has been removed in favor of direct imports. We also added support for **topic with dynamic ID** — a powerful feature that lets you subscribe to specific entity changes (e.g. comments on a specific post).
+
+The subscription system is not tied to any specific server — you can use it with Apollo Server, GraphQL Yoga, or any other GraphQL server that supports subscriptions. And if the built-in PubSub doesn't meet your needs, you can provide your own implementation as long as it matches the `PubSub` interface. There's even a [Redis subscriptions example](https://github.com/MichalLytek/type-graphql/tree/master/examples/redis-subscriptions) in the repo for distributed setups.
+
+## Class-based auth checker
+
+One of the most requested features was the ability to use dependency injection in auth checkers. In 1.x, the `authChecker` option only accepted a plain function, which made it awkward to access services or repositories.
+
+Now in 2.0, the `authChecker` option also supports **class-based auth checkers** — your auth checker can receive injected services just like your resolvers:
+
+```ts
+import { type AuthCheckerInterface, type ResolverData } from "type-graphql";
+
+class CustomAuthChecker implements AuthCheckerInterface<Context> {
+  constructor(private readonly userService: UserService) {}
+
+  check({ context }: ResolverData<Context>, roles: string[]) {
+    const user = this.userService.getByToken(context.token);
+    if (!user) return false;
+    return roles.length === 0 || roles.includes(user.role);
+  }
+}
+```
+
+We also added support for applying `@Authorized()` at the **resolver class level**, so you can protect all queries and mutations in a resolver with a single decorator instead of annotating each handler individually.
+
+The old `UnauthorizedError` and `ForbiddenError` classes have been replaced with `AuthenticationError` and `AuthorizationError` that properly extend `GraphQLError` — more on that in the [error handling section](#graphql-native-error-handling).
+
+## Validation rework
+
+The validation system got a pretty big rework:
+
+**Validation is now opt-in.** The `validate` option defaults to `false`, and `class-validator` became an optional peer dependency. If you don't use validation, you don't need to install it at all. If you do, just set `validate: true` in `buildSchema`.
+
+**Custom validation functions** have their own dedicated `validateFn` option (instead of overloading `validate`). The `ValidatorFn` signature also changed — it now receives the full resolver data (`argValue`, `argType`, and `{ root, args, context, info }`), so you can do things like context-aware validation.
+
+**Per-argument validation** is also new — you can pass `validateFn` directly on `@Arg()` and `@Args()` decorators to validate individual arguments differently.
+
+## Custom decorators
+
+The custom decorator API got some attention too. First, some renames — `createMethodDecorator` is now `createMethodMiddlewareDecorator` and `createParamDecorator` is now `createParameterDecorator`. The old names were a bit misleading about what they actually did.
+
+There's also a new `createResolverClassMiddlewareDecorator` that lets you apply middleware to **all handlers in a resolver class** at once — handy for logging, metrics, that sort of thing.
+
+But the most interesting addition is that `createParameterDecorator` now accepts `CustomParameterOptions` with an `arg` property, so your custom decorator can also **register a GraphQL argument in the schema**:
+
+```ts
+function CurrentPage() {
+  return createParameterDecorator(
+    ({ args }) => args.page,
+    {
+      arg: {
+        name: "page",
+        typeFunc: () => Int,
+        options: { defaultValue: 1 },
+      },
+    },
+  );
+}
+
+// Usage in resolver:
+@Query(() => [Recipe])
+recipes(@CurrentPage() page: number) { ... }
+```
+
+## ESM support
+
+TypeGraphQL 2.0 ships both CommonJS and ESM bundles. If your project uses `"type": "module"` in `package.json`, it should just work — no extra config needed.
+
+There's also a new `type-graphql/shim` entry point for browser/frontend usage (e.g. sharing types between server and client) where `reflect-metadata` isn't available. It exports no-op decorators so TypeScript stays happy without pulling in the full runtime.
+
+## Scalars from the ecosystem
+
+Rather than maintaining our own date scalar implementations, TypeGraphQL 2.0 uses the [`graphql-scalars`](https://the-guild.dev/graphql/scalars) package from The Guild.
+
+The `graphql-scalars` package is now a required peer dependency, and the exported `GraphQLISODateTime` scalar is actually a re-export of `GraphQLDateTimeISO`. The old `dateScalarMode` option has been removed in favor of the more flexible `scalarsMap` approach:
+
+```ts
+import { GraphQLTimestamp } from "graphql-scalars";
+
+const schema = await buildSchema({
+  resolvers,
+  scalarsMap: [{ type: Date, scalar: GraphQLTimestamp }],
+});
+```
+
+One thing to be aware of: the default date scalar is now registered in the schema as `DateTimeISO` instead of `DateTime`. Check the [migration guide](https://typegraphql.com/docs/migration-guide) for a simple snippet to restore the old name if needed.
+
+## GraphQL-native error handling
+
+All TypeGraphQL error classes now properly extend `GraphQLError` from the `graphql` package, with structured error information in the standard `extensions` property:
+
+| Error class               | `extensions.code`   | Purpose                   |
+| ------------------------- | ------------------- | ------------------------- |
+| `AuthenticationError`     | `"UNAUTHENTICATED"` | User not authenticated    |
+| `AuthorizationError`      | `"UNAUTHORIZED"`    | User lacks required roles |
+| `ArgumentValidationError` | `"BAD_USER_INPUT"`  | Input validation failed   |
+
+Error details like validation errors are now accessible through `error.extensions.validationErrors` instead of custom properties. This plays nicely with Apollo Server's `formatError`, GraphQL Yoga's `maskError`, and other server error handling mechanisms.
+
+## Performance and build improvements
+
+Some things worth mentioning under the hood:
+
+- **HashMap-based metadata caching** for O(1) lookups during schema building, replacing O(n) scans. Makes a real difference if you build multiple schemas or have a large codebase.
+- **`buildSchemaSync` now validates** the generated schema via introspection — no more silently producing invalid schemas that blow up at query time.
+- **ES2021 build target** and **Node.js >= 20.11.1** required — we dropped older runtimes to keep things simple.
+
+## Migration guide
+
+There's a lot of breaking changes in a major release like this, so we wrote a proper [migration guide](https://typegraphql.com/docs/migration-guide) with before/after code examples for each one. If you're upgrading from v1.x, start there.
+
+The TL;DR: update peer deps, turn on validation explicitly if you use it, rename a few imports, and switch your PubSub setup if you use subscriptions.
+
+```sh
+npm install type-graphql graphql@^16.12.0 graphql-scalars@^1.25.0
+```
+
+## What's next?
+
+With 2.0 out, here's what's on the radar:
+
+- Support for the [TC39 decorators proposal](https://github.com/tc39/proposal-decorators) as it stabilizes in TypeScript
+- More examples and better docs
+- Continued performance work
+
+Thanks to everyone who tested the betas and RCs, reported bugs, and submitted PRs — this release is as much yours as it is ours 💪
+
+If TypeGraphQL is useful to you, consider [starring the repo](https://github.com/MichalLytek/type-graphql) ⭐ or [becoming a sponsor](https://github.com/sponsors/MichalLytek) to keep the project going 😉

--- a/website/blog/2026-03-26-typegraphql-2.md
+++ b/website/blog/2026-03-26-typegraphql-2.md
@@ -155,11 +155,29 @@ Beyond the headline features, there's a bunch of smaller additions that are wort
 
 ## Performance and build improvements
 
-Some things worth mentioning under the hood:
+In the [1.0 release](./2020-08-19-devto-article.md), we cut the overhead of TypeGraphQL over raw `graphql-js` from 500% down to ~17%. For 2.0, the focus shifted to **schema building performance** — the time it takes to go from your decorated classes to a working `GraphQLSchema` object.
 
-- **HashMap-based metadata caching** for O(1) lookups during schema building, replacing O(n) scans. Makes a real difference if you build multiple schemas or have a large codebase.
-- **`buildSchemaSync` now validates** the generated schema via introspection — no more silently producing invalid schemas that blow up at query time.
-- **ES2021 build target** and **Node.js >= 20.11.1** required — we dropped older runtimes to keep things simple.
+### HashMap-based metadata caching
+
+The biggest change is the internal metadata storage rework (#1779). In 1.x, looking up metadata for a class (its fields, middlewares, auth config, directives, etc.) meant scanning flat arrays with `.find()` and `.filter()` — O(n) per lookup, repeated for every type and field during schema building.
+
+In 2.0, we introduced HashMap caches for 11 different metadata categories (object types, interface types, authorized fields, middlewares, directives, resolver classes, fields, params, and more). All lookups are now O(1) via `Map.get()`. For large schemas with hundreds of types, this makes a real difference in `buildSchema` time.
+
+### Validation is opt-in
+
+Making `class-validator` optional and defaulting `validate` to `false` means projects that don't use argument validation skip the entire validation middleware layer. No `class-validator` import, no validation function wrapping — the code path simply doesn't exist unless you opt in.
+
+### Removed glob path overhead
+
+Dropping glob-based resolver loading removed the dynamic `require` calls and file system scanning that happened at schema build time. Explicit imports are resolved statically by the bundler or runtime, which is both faster and more predictable.
+
+### Safe multi-schema builds
+
+Building multiple schemas from the same set of decorators (e.g. a public and admin schema) was fragile in 1.x — metadata could get duplicated or corrupted across builds. In 2.0, the schema generator works on a local clone of the metadata storage (#1698, #1803), so each `buildSchema` call starts clean. The HashMap caches are also rebuilt per-build to prevent stale lookups.
+
+### ES2021 build target and graphql-js v16
+
+The package now targets ES2021 (up from ES2018) and requires Node.js >= 20.11.1, which means native support for modern JS features without transpilation overhead. The jump to `graphql-js` v16 also brings its own internal performance improvements from the reference implementation.
 
 ## Migration guide
 

--- a/website/blog/2026-03-26-typegraphql-2.md
+++ b/website/blog/2026-03-26-typegraphql-2.md
@@ -18,6 +18,7 @@ Well, then, without further ado... let's take a look what TypeGraphQL 2.0 brings
 - [ESM support](#esm-support)
 - [Scalars from the ecosystem](#scalars-from-the-ecosystem)
 - [GraphQL-native error handling](#graphql-native-error-handling)
+- [Other improvements](#other-improvements)
 - [Performance and build improvements](#performance-and-build-improvements)
 - [Migration guide](#migration-guide)
 - [What's next?](#whats-next)
@@ -138,6 +139,19 @@ All TypeGraphQL error classes now properly extend `GraphQLError` from the `graph
 | `ArgumentValidationError` | `"BAD_USER_INPUT"`  | Input validation failed   |
 
 Error details like validation errors are now accessible through `error.extensions.validationErrors` instead of custom properties. This plays nicely with Apollo Server's `formatError`, GraphQL Yoga's `maskError`, and other server error handling mechanisms.
+
+## Other improvements
+
+Beyond the headline features, there's a bunch of smaller additions that are worth knowing about:
+
+- **Directives on interface types and their fields** (#744), with automatic inheritance to implementing object types
+- **Directives on `@Arg` and `@Args` fields** — you can now apply `@Directive()` on inline `@Arg` and on `@Field` within `@Args` classes
+- **Deprecating input fields and args** (#794) — `deprecationReason` now works on input fields, not just output fields
+- **`buildTypeDefsAndResolversSync`** (#803) — a sync version of `buildTypeDefsAndResolvers` for cases where you can't use async
+- **Readonly arrays for `@Authorized` roles** (#935) — `@Authorized(roles)` now accepts `readonly` arrays
+- **Disabling default value inference** (#793) — you can now opt out of TypeGraphQL inferring default values from class field initializers
+- **No more `implements` chain restriction** (#1425) — you no longer need to list every interface in the inheritance chain in `@ObjectType({ implements: [...] })`
+- **Alternative `Reflect` polyfills** (#1102) — TypeGraphQL now only checks for the specific `Reflect` API methods it uses, so polyfills other than `reflect-metadata` work too
 
 ## Performance and build improvements
 

--- a/website/blog/2026-03-26-typegraphql-2.md
+++ b/website/blog/2026-03-26-typegraphql-2.md
@@ -32,7 +32,7 @@ One of the biggest changes in 2.0 is the subscriptions system. The old [`graphql
 The new PubSub system is type-safe out of the box. You define your topic types once, and TypeScript makes sure you publish the right payload to the right topic:
 
 ```ts
-import { createPubSub } from "@graphql-yoga/subscriptions";
+import { createPubSub } from "@graphql-yoga/subscription";
 
 export const pubSub = createPubSub<{
   NOTIFICATIONS: [NotificationPayload];


### PR DESCRIPTION
## Summary

- Expands the migration guide (`docs/migration-guide.md`) to cover all breaking changes from v1.x to v2.0 — resolver loading, auth system, validation, error classes, scalars, custom decorators, deprecated options, nullability, build target, ESM, and peer dependencies. Each section includes before/after code examples.
- Adds an announcement blog post (`website/blog/2026-03-26-typegraphql-2.md`) for the v2.0 stable release, covering the major features and linking to the migration guide.

Closes #1418

## Test plan

- [ ] Review migration guide sections against CHANGELOG.md breaking changes for completeness
- [ ] Verify code examples match current API (types, signatures, imports)
- [ ] Run `npm run build` in `website/` to confirm Docusaurus builds cleanly
- [ ] Check blog post renders correctly in local dev server
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/michallytek/type-graphql/pull/1808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
